### PR TITLE
Add ServerOptions to worker interface

### DIFF
--- a/packages/worker/native/index.d.ts
+++ b/packages/worker/native/index.d.ts
@@ -1,7 +1,31 @@
+export interface ServerOptions {
+  /**
+   * The URL of the Temporal server to connect to
+   */
+  url: string;
+  /**
+   * What namespace will we operate under
+   */
+  namespace: string;
+
+  /**
+   * A human-readable string that can identify your worker
+   */
+  identity: string;
+  /**
+   * A string that should be unique to the exact worker code/binary being executed
+   */
+  workerBinaryId: string;
+  /**
+   * Timeout for long polls (polling of task queues)
+   */
+  longPollTimeoutMs: number;
+}
+
 export interface Worker {}
 
 export declare type PollCallback = (err?: Error, result: ArrayBuffer) => void;
-export declare function newWorker(): Worker;
+export declare function newWorker(serverOptions: ServerOptions): Worker;
 export declare function workerShutdown(worker: Worker): void;
 export declare function workerPoll(worker: Worker, queueName: string, callback: PollCallback): void;
 export declare function workerCompleteTask(worker: Worker, result: ArrayBuffer): void;

--- a/packages/worker/tsconfig.json
+++ b/packages/worker/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "resolveJsonModule": true,
     "outDir": "./lib",
     "rootDir": "./src"
   },


### PR DESCRIPTION
<!--- Reminder to change the title 👆 -->

## Description, Motivation and Context

<!--- For All  Contributors -->

<!--- What was changed? Is this a bugfix or new feature? Include screenshots if relevant -->
What was changed:

Added the basic functionality of configuring the worker's server connection.

<!--- If it fixes an open issue, please link to the issue here. -->
Closes issue: 

Closes #38 

## How has this been tested?
<!--- Please describe how you tested your changes/how we can test them -->

Added a test that asserts the worker options are generated correctly

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
