### PR TITLE
Temporarily disable Windows build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,9 @@ jobs:
           toolchain: stable
       - run: |
           rustup target add aarch64-apple-darwin
-          rustup target add x86_64-pc-windows-gnu
           rustup target add x86_64-unknown-linux-gnu
           brew tap SergioBenitez/osxct
           brew install x86_64-unknown-linux-gnu
-          brew install mingw-w64
       - run: cp etc/mac-cargo-config.toml ~/.cargo/config.toml
       - uses: actions/setup-node@v1
         with:
@@ -70,7 +68,8 @@ jobs:
         run: npx lerna run --stream build-rust
         env:
           # aarch64 build fails on GH actions, skip it since we can't test it anyways
-          TEMPORAL_WORKER_BUILD_TARGETS: 'x86_64-apple-darwin:x86_64-unknown-linux-gnu:x86_64-pc-windows-gnu'
+          # windows build temporarily disabled due to brew issues
+          TEMPORAL_WORKER_BUILD_TARGETS: 'x86_64-apple-darwin:x86_64-unknown-linux-gnu'
       - run: node scripts/publish-to-verdaccio.js --registry-dir /tmp/registry
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
This should be reverted as soon as the brew install issue for `mingw-w64` is fixed.