### PR TITLE
Move __dirname Worker.create() param into WorkerOptions

### DIFF
--- a/packages/create-project/samples/worker.ts
+++ b/packages/create-project/samples/worker.ts
@@ -2,11 +2,12 @@
 import { Worker } from '@temporalio/worker';
 
 async function run() {
-  // Automatically locate and register activities and workflows
+  // Automatically locate and register Activities and Workflows relative to __dirname
   // (assuming package was bootstrapped with `npm init @temporalio`).
   // Worker connects to localhost by default and uses console error for logging.
-  // Customize the worker by passing options a second parameter of `create()`.
-  const worker = await Worker.create(__dirname, { taskQueue: 'tutorial' });
+  // Customize the Worker by passing more options to create().
+  // create() tries to connect to the server and will throw if a connection could not be established.
+  const worker = await Worker.create({ workDir: __dirname, taskQueue: 'tutorial' });
   // Start accepting tasks on the `tutorial` queue
   await worker.run();
 }

--- a/packages/test/src/mock-native-worker.ts
+++ b/packages/test/src/mock-native-worker.ts
@@ -125,8 +125,8 @@ export class Worker extends RealWorker {
     return this.nativeWorker as MockNativeWorker;
   }
 
-  public constructor(pwd: string, opts: WorkerOptions) {
+  public constructor(opts: WorkerOptions) {
     const nativeWorker = new MockNativeWorker();
-    super(nativeWorker, compileWorkerOptions(addDefaults(pwd, opts)));
+    super(nativeWorker, compileWorkerOptions(addDefaults(opts)));
   }
 }

--- a/packages/test/src/run-a-worker.ts
+++ b/packages/test/src/run-a-worker.ts
@@ -1,7 +1,7 @@
 import { Worker } from '@temporalio/worker';
 
 async function main() {
-  const worker = await Worker.create(__dirname, {
+  const worker = await Worker.create({
     workflowsPath: `${__dirname}/../../test-workflows/lib`,
     activitiesPath: `${__dirname}/../../test-activities/lib`,
     taskQueue: 'test',

--- a/packages/test/src/test-integration.ts
+++ b/packages/test/src/test-integration.ts
@@ -31,7 +31,7 @@ const test = anyTest as TestInterface<Context>;
 
 if (RUN_INTEGRATION_TESTS) {
   test.before(async (t) => {
-    const worker = await Worker.create(__dirname, {
+    const worker = await Worker.create({
       workflowsPath: `${__dirname}/../../test-workflows/lib`,
       activitiesPath: `${__dirname}/../../test-activities/lib`,
       logger: new DefaultLogger('DEBUG'),

--- a/packages/test/src/test-worker-activities.ts
+++ b/packages/test/src/test-worker-activities.ts
@@ -21,7 +21,7 @@ export async function runWorker(t: ExecutionContext<Context>, fn: () => Promise<
 }
 
 test.beforeEach((t) => {
-  const worker = new Worker(__dirname, {
+  const worker = new Worker({
     activitiesPath: `${__dirname}/../../test-activities/lib`,
     taskQueue: 'test',
   });

--- a/packages/test/src/test-worker-lifecycle.ts
+++ b/packages/test/src/test-worker-lifecycle.ts
@@ -10,9 +10,8 @@ import { RUN_INTEGRATION_TESTS } from './helpers';
 
 if (RUN_INTEGRATION_TESTS) {
   test.serial.skip('run shuts down gracefully', async (t) => {
-    const worker = await Worker.create(__dirname, {
+    const worker = await Worker.create({
       shutdownGraceTime: '500ms',
-      activitiesPath: null,
       taskQueue: 'shutdown-test',
     });
     t.is(worker.getState(), 'INITIALIZED');
@@ -27,9 +26,8 @@ if (RUN_INTEGRATION_TESTS) {
 }
 
 test.serial('Mocked run shuts down gracefully', async (t) => {
-  const worker = new MockedWorker(__dirname, {
+  const worker = new MockedWorker({
     shutdownGraceTime: '500ms',
-    activitiesPath: null,
     taskQueue: 'shutdown-test',
   });
   t.is(worker.getState(), 'INITIALIZED');
@@ -43,9 +41,8 @@ test.serial('Mocked run shuts down gracefully', async (t) => {
 });
 
 test.serial('Mocked run throws if not shut down gracefully', async (t) => {
-  const worker = new MockedWorker(__dirname, {
+  const worker = new MockedWorker({
     shutdownGraceTime: '5ms',
-    activitiesPath: null,
     taskQueue: 'shutdown-test',
   });
   t.is(worker.getState(), 'INITIALIZED');
@@ -61,9 +58,8 @@ test.serial('Mocked run throws if not shut down gracefully', async (t) => {
 });
 
 test('Mocked worker suspends and resumes', async (t) => {
-  const worker = new MockedWorker(__dirname, {
+  const worker = new MockedWorker({
     shutdownGraceTime: '5ms',
-    activitiesPath: null,
     taskQueue: 'suspend-test',
   });
   const p = worker.run();

--- a/packages/test/src/test-worker.ts
+++ b/packages/test/src/test-worker.ts
@@ -15,14 +15,14 @@ test('resolver resolves without .js extension', async (t) => {
 });
 
 test('resolver throws if no override', async (t) => {
-  const resolve = resolver(null, new Map());
+  const resolve = resolver(undefined, new Map());
   const err = await t.throwsAsync(() => resolve(__filename.replace(`${__dirname}/`, '')));
   t.true(err instanceof LoaderError);
   t.regex(err.message, /Could not find \S+ in overrides and no baseDir provided/);
 });
 
 test('resolver uses override', async (t) => {
-  const resolve = resolver(null, new Map([['test', __filename]]));
+  const resolve = resolver(undefined, new Map([['test', __filename]]));
   const resolved = await resolve('test');
   t.is(resolved, __filename);
 });


### PR DESCRIPTION
## What was changed:
Move __dirname Worker.create() param into WorkerOptions.

## Why?
It simplifies using and explaining `WorkerOptions` by removing the need for `null`s in `workflowsPath` and `activitiesPath`.

## Checklist

1. Closes issue: 
None

2. How was this tested:
Standard test suitte.

3. Any docs updates needed?
Updated the documentation and sample for the docs site.
