### PR TITLE
Add Activity Info to context, test cancellation with signals

### DIFF
--- a/packages/activity/src/index.ts
+++ b/packages/activity/src/index.ts
@@ -1,19 +1,19 @@
 /**
  * This library provides tools for authoring activities.
  *
- * Import this module from activity code - must **not** be used in workflows.
+ * Import this module from Activity code - must **not** be used in Workflows.
  *
- * Any function can be used as an activity as long as its parameters and return value are serialiable using a [`DataConverter`](../interfaces/worker.dataconverter.md).
+ * Any function can be used as an Activity as long as its parameters and return value are serialiable using a [`DataConverter`](../interfaces/worker.dataconverter.md).
  *
  * ### Cancellation
  * Activities may be cancelled only if they [emit heartbeats](../classes/activity.context.md#heartbeat).<br/>
- * There are 2 ways to handle activity cancellation:
+ * There are 2 ways to handle Activity cancellation:
  * 1. await on [`Context.current().cancelled`](../classes/activity.context.md#cancelled)
  * 1. Pass the context's [abort signal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) at [`Context.current().cancellationSignal`](../classes/activity.context.md#cancellationsignal) to a library that supports it
  *
  * ### Examples
  *
- * #### An activity that fakes progress and can be cancelled
+ * #### An Activity that fakes progress and can be cancelled
  * ```ts
  * import { Context, CancellationError } from '@temporalio/activity';
  *
@@ -21,7 +21,7 @@
  *   try {
  *     for (let progress = 1; progress <= 100; ++progress) {
  *       const timer = new Promise((resolve) => setTimeout(resolve, 1000));
- *       // sleep for 1 second or throw if activity is cancelled
+ *       // sleep for 1 second or throw if Activity is cancelled
  *       await Promise.race([Context.current().cancelled, timer]);
  *       Context.current().heartbeat(progress);
  *     }
@@ -34,7 +34,7 @@
  * }
  * ```
  *
- * #### An activity that makes a cancellable HTTP request
+ * #### An Activity that makes a cancellable HTTP request
  * ```ts
  * import fetch from 'node-fetch';
  * import { Context } from '@temporalio/activity';
@@ -67,53 +67,125 @@ import { AbortSignal } from 'abort-controller';
 import { asyncLocalStorage } from './internals';
 
 /**
- * Thrown in an activity when the activity is cancelled while awaiting {@link Context.cancelled}.
+ * Thrown in an Activity when the Activity is cancelled while awaiting {@link Context.cancelled}.
  *
- * The activity must {@link Context.heartbeat | send heartbeats} in order to be cancellable.
+ * The Activity must {@link Context.heartbeat | send heartbeats} in order to be cancellable.
  */
 export class CancellationError extends Error {
   public readonly name: string = 'CancellationError';
 }
 
 /**
+ * Holds information about the current executing Activity
+ */
+export interface Info {
+  taskToken: Uint8Array;
+  activityId: string;
+  /**
+   * Tuple containing the Activity module name and function name
+   */
+  activityType: [string, string];
+  /**
+   * The namespace this Activity is running in
+   */
+  activityNamespace: string;
+  /**
+   * Attempt number for this activity
+   */
+  attempt: number;
+  /**
+   * Whether this activity is scheduled in local or remote mode
+   */
+  isLocal: boolean;
+  /**
+   * Information about the Workflow that scheduled the Activity
+   */
+  workflowExecution: {
+    workflowId: string;
+    runId: string;
+  };
+  /**
+   * The namespace of the Workflow that scheduled this Activity
+   */
+  workflowNamespace: string;
+  /**
+   * The module name of the Workflow that scheduled this Activity
+   */
+  workflowType: string;
+  /**
+   * Timestamp for when this Activity was scheduled in milliseconds
+   */
+  scheduledTimestampMs: number;
+  /**
+   * Timeout for this Activity from schedule to close in milliseconds
+   */
+  scheduleToCloseTimeoutMs: number;
+  /**
+   * Timeout for this Activity from start to close in milliseconds
+   */
+  startToCloseTimeoutMs: number;
+  /**
+   * Heartbeat timeout in milliseconds.
+   * If this timeout is defined, the Activity must heartbeat before the timeout is reached.
+   * The Activity must **not** heartbeat in case this timeout is not defined.
+   */
+  heartbeatTimeoutMs?: number;
+  /**
+   * Hold the details supplied to the last heartbeat on previous attempts of this Activity.
+   * Use this in order to resume your Activity from checkpoint.
+   */
+  heartbeatDetails: any;
+}
+
+/**
  * Activity Context manager.
  *
- * Call `Context.current()` from activity code in order to send heartbeats and get notified of activity cancellation.
+ * Call `Context.current()` from Activity code in order to send heartbeats and get notified of Activity cancellation.
  */
 export class Context {
+  /**
+   * Holds information about the current executing Activity
+   */
+  public info: Info;
   protected cancel: (reason?: any) => void = () => undefined;
   /**
-   * Await this promise in an activity to get notified of cancellation.
+   * Await this promise in an Activity to get notified of cancellation.
    *
    * This promise will never be resolved, it will only be rejected with a {@link CancellationError}.
    */
   public readonly cancelled: Promise<never>;
   /**
-   * An `AbortSignal` which can be used to cancel requests on activity cancellation.
+   * An `AbortSignal` which can be used to cancel requests on Activity cancellation.
    *
    * Typically used by the {@link https://www.npmjs.com/package/node-fetch#request-cancellation-with-abortsignal | fetch} and {@link https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options child_process} libraries but is supported by a few other libraries as well.
    */
   public readonly cancellationSignal: AbortSignal;
   /**
-   * Send a heartbeat from an activity.
+   * Send a heartbeat from an Activity.
    *
    * If an Activity times out, the last value of details is included in the ActivityTimeoutException delivered to a Workflow. Then the Workflow can pass the details to the next Activity invocation. This acts as a periodic checkpoint mechanism for the progress of an Activity.
    */
   public readonly heartbeat: (details: any) => void;
 
   /**
-   * **Not** meant to instantiated by activity code, used by the worker.
+   * **Not** meant to instantiated by Activity code, used by the worker.
    *
    * @ignore
    */
-  constructor(cancelled: Promise<never>, cancellationSignal: AbortSignal, heartbeat: (details: any) => void) {
+  constructor(
+    info: Info,
+    cancelled: Promise<never>,
+    cancellationSignal: AbortSignal,
+    heartbeat: (details: any) => void
+  ) {
+    this.info = info;
     this.cancelled = cancelled;
     this.cancellationSignal = cancellationSignal;
     this.heartbeat = heartbeat;
   }
 
   /**
-   * Gets the context of the current activity.
+   * Gets the context of the current Activity.
    *
    * Uses {@link https://nodejs.org/docs/latest-v14.x/api/async_hooks.html#async_hooks_class_asynclocalstorage | AsyncLocalStorage} under the hood to make it accessible in nested callbacks and promises.
    */

--- a/packages/test-interfaces/src/index.ts
+++ b/packages/test-interfaces/src/index.ts
@@ -50,5 +50,9 @@ export interface Sleeper extends Workflow {
 }
 
 export interface CancellableHTTPRequest extends Workflow {
-  main(url: string, completeOnActivityCancellation?: boolean): Promise<void>;
+  main(url: string, completeOnActivityCancellation: boolean): Promise<void>;
+  signals: {
+    activityStarted(): void;
+    activityCancelled(): void;
+  };
 }

--- a/packages/test-workflows/src/cancel-http-request.ts
+++ b/packages/test-workflows/src/cancel-http-request.ts
@@ -1,6 +1,7 @@
 import { Context, CancellationError, cancel, sleep } from '@temporalio/workflow';
 import { CancellableHTTPRequest } from '@interfaces';
 import { cancellableFetch } from '@activities';
+import { ResolvablePromise } from './resolvable-promise';
 
 const fetch = Context.configure(cancellableFetch, {
   type: 'remote',
@@ -8,22 +9,38 @@ const fetch = Context.configure(cancellableFetch, {
   heartbeatTimeout: '3s',
 });
 
-async function main(url: string, completeOnActivityCancellation = false): Promise<void> {
-  const promise = fetch(url);
-  // TODO: wait on signal from activity instead of sleeping
-  await sleep(3000);
+const activityStarted = new ResolvablePromise<void>();
+const activityCancelled = new ResolvablePromise<void>();
+
+const signals = {
+  activityStarted() {
+    activityStarted.resolve(undefined);
+  },
+  activityCancelled() {
+    activityCancelled.resolve(undefined);
+  },
+};
+
+async function main(url: string, waitForActivityCancelled: boolean): Promise<void> {
+  const promise = fetch(url, true);
+  await activityStarted;
   cancel(promise);
   try {
     await promise;
   } catch (err) {
     if (err instanceof CancellationError) {
-      if (!completeOnActivityCancellation) {
-        // TODO: wait on signal from activity instead of sleeping
-        await sleep(3000);
+      if (waitForActivityCancelled) {
+        await Promise.race([
+          activityCancelled,
+          (async () => {
+            await sleep(10000);
+            throw new Error('Confirmation of activity cancellation never arrived');
+          })(),
+        ]);
       }
     }
     throw err;
   }
 }
 
-export const workflow: CancellableHTTPRequest = { main };
+export const workflow: CancellableHTTPRequest = { main, signals };

--- a/packages/test-workflows/src/cancel-http-request.ts
+++ b/packages/test-workflows/src/cancel-http-request.ts
@@ -13,10 +13,10 @@ const activityStarted = new ResolvablePromise<void>();
 const activityCancelled = new ResolvablePromise<void>();
 
 const signals = {
-  activityStarted() {
+  activityStarted(): void {
     activityStarted.resolve(undefined);
   },
-  activityCancelled() {
+  activityCancelled(): void {
     activityCancelled.resolve(undefined);
   },
 };

--- a/packages/test-workflows/src/resolvable-promise.ts
+++ b/packages/test-workflows/src/resolvable-promise.ts
@@ -1,8 +1,12 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 
 /**
- * Helper for creating promises which can be manually resolved
- * Copied from workflow/common
+ * Helper for creating promises which can be manually resolved.
+ * Copied from workflow/common because of a limitation of the module loader
+ * which doesn't inject it into the workflow runtime.
+ *
+ * TODO(bergundy): Export a transferable ResolvablePromise that considers
+ * scopes and cancellation.
  */
 export class ResolvablePromise<T> implements PromiseLike<T> {
   public readonly then: <TResult1 = T, TResult2 = never>(

--- a/packages/test-workflows/src/resolvable-promise.ts
+++ b/packages/test-workflows/src/resolvable-promise.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+
 /**
  * Helper for creating promises which can be manually resolved
  * Copied from workflow/common

--- a/packages/test-workflows/src/resolvable-promise.ts
+++ b/packages/test-workflows/src/resolvable-promise.ts
@@ -1,0 +1,25 @@
+/**
+ * Helper for creating promises which can be manually resolved
+ * Copied from workflow/common
+ */
+export class ResolvablePromise<T> implements PromiseLike<T> {
+  public readonly then: <TResult1 = T, TResult2 = never>(
+    onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null,
+    onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null
+  ) => PromiseLike<TResult1 | TResult2>;
+
+  // @ts-ignore
+  public readonly resolve: (value: T | PromiseLike<T>) => void;
+  // @ts-ignore
+  public readonly reject: (reason?: any) => void;
+
+  constructor() {
+    const promise = new Promise<T>((resolve, reject) => {
+      // @ts-ignore
+      this.resolve = resolve;
+      // @ts-ignore
+      this.reject = reject;
+    });
+    this.then = promise.then.bind(promise);
+  }
+}

--- a/packages/test/src/test-integration.ts
+++ b/packages/test/src/test-integration.ts
@@ -78,22 +78,21 @@ if (RUN_INTEGRATION_TESTS) {
     t.is(res, 'Hello, world!');
   });
 
-  const testCancelHTTPRequest = async (t: ExecutionContext<Context>, completeOnActivityCancellation: boolean) => {
-    const client = new Connection();
-    await withZeroesHTTPServer(async (port, activityProperlyCancelled) => {
+  const testCancelHTTPRequest = async (t: ExecutionContext<Context>, waitForActivityCancelled: boolean) => {
+    await withZeroesHTTPServer(async (port) => {
+      const client = new Connection();
       const url = `http://127.0.0.1:${port}`;
       const workflow = client.workflow<CancellableHTTPRequest>('cancel-http-request', { taskQueue: 'test' });
-      await t.throwsAsync(() => workflow.start(url, completeOnActivityCancellation), {
+      await t.throwsAsync(() => workflow.start(url, waitForActivityCancelled), {
         message: 'Activity cancelled',
         instanceOf: WorkflowExecutionFailedError,
       });
-      await activityProperlyCancelled;
     });
   };
 
-  test('cancel-http-request completeOnActivityCancellation', (t) => testCancelHTTPRequest(t, true));
+  test('cancel-http-request waitForActivityCancelled', (t) => testCancelHTTPRequest(t, true));
 
-  test("cancel-http-request don't completeOnActivityCancellation", (t) => testCancelHTTPRequest(t, false));
+  test("cancel-http-request don't waitForActivityCancelled", (t) => testCancelHTTPRequest(t, false));
 
   test('activity-failure', async (t) => {
     const client = new Connection();

--- a/packages/test/src/test-integration.ts
+++ b/packages/test/src/test-integration.ts
@@ -79,7 +79,7 @@ if (RUN_INTEGRATION_TESTS) {
   });
 
   const testCancelHTTPRequest = async (t: ExecutionContext<Context>, waitForActivityCancelled: boolean) => {
-    await withZeroesHTTPServer(async (port) => {
+    await withZeroesHTTPServer(async (port, finished) => {
       const client = new Connection();
       const url = `http://127.0.0.1:${port}`;
       const workflow = client.workflow<CancellableHTTPRequest>('cancel-http-request', { taskQueue: 'test' });
@@ -87,6 +87,7 @@ if (RUN_INTEGRATION_TESTS) {
         message: 'Activity cancelled',
         instanceOf: WorkflowExecutionFailedError,
       });
+      await finished;
     });
   };
 

--- a/packages/test/src/test-worker-activities.ts
+++ b/packages/test/src/test-worker-activities.ts
@@ -108,7 +108,7 @@ test('Worker cancels activity and reports cancellation', async (t) => {
 test('Activity Context AbortSignal cancels a fetch request', async (t) => {
   const { worker } = t.context;
   await runWorker(t, async () => {
-    await withZeroesHTTPServer(async (port) => {
+    await withZeroesHTTPServer(async (port, finished) => {
       const taskToken = Buffer.from(uuid4());
       worker.native.emit({
         activity: {
@@ -128,6 +128,7 @@ test('Activity Context AbortSignal cancels a fetch request', async (t) => {
       compareCompletion(t, completion.result, {
         canceled: {},
       });
+      await finished;
     });
   });
 });

--- a/packages/test/src/test-worker-activities.ts
+++ b/packages/test/src/test-worker-activities.ts
@@ -108,7 +108,7 @@ test('Worker cancels activity and reports cancellation', async (t) => {
 test('Activity Context AbortSignal cancels a fetch request', async (t) => {
   const { worker } = t.context;
   await runWorker(t, async () => {
-    await withZeroesHTTPServer(async (port, finished) => {
+    await withZeroesHTTPServer(async (port) => {
       const taskToken = Buffer.from(uuid4());
       worker.native.emit({
         activity: {
@@ -116,7 +116,7 @@ test('Activity Context AbortSignal cancels a fetch request', async (t) => {
           activityId: 'abc',
           start: {
             activityType: JSON.stringify(['@activities', 'cancellableFetch']),
-            input: defaultDataConverter.toPayloads(`http://127.0.0.1:${port}`),
+            input: defaultDataConverter.toPayloads(`http://127.0.0.1:${port}`, false),
           },
         },
       });
@@ -128,7 +128,6 @@ test('Activity Context AbortSignal cancels a fetch request', async (t) => {
       compareCompletion(t, completion.result, {
         canceled: {},
       });
-      await finished;
     });
   });
 });

--- a/packages/test/src/test-worker-activities.ts
+++ b/packages/test/src/test-worker-activities.ts
@@ -2,7 +2,6 @@
 import anyTest, { TestInterface, ExecutionContext } from 'ava';
 import { v4 as uuid4 } from 'uuid';
 import { coresdk } from '@temporalio/proto';
-import { DefaultLogger } from '@temporalio/worker';
 import { defaultDataConverter } from '@temporalio/workflow/commonjs/converter/data-converter';
 import { httpGet } from '../../test-activities/lib';
 import { Worker } from './mock-native-worker';

--- a/packages/test/src/test-worker-activities.ts
+++ b/packages/test/src/test-worker-activities.ts
@@ -2,6 +2,7 @@
 import anyTest, { TestInterface, ExecutionContext } from 'ava';
 import { v4 as uuid4 } from 'uuid';
 import { coresdk } from '@temporalio/proto';
+import { DefaultLogger } from '@temporalio/worker';
 import { defaultDataConverter } from '@temporalio/workflow/commonjs/converter/data-converter';
 import { httpGet } from '../../test-activities/lib';
 import { Worker } from './mock-native-worker';

--- a/packages/test/src/zeroes-http-server.ts
+++ b/packages/test/src/zeroes-http-server.ts
@@ -1,39 +1,26 @@
 import http from 'http';
 import { sleep } from './helpers';
-import { ResolvablePromise } from '@temporalio/workflow/commonjs/common';
 
 /**
- * Creates an HTTP server which responds with zeroes on /zeros.
- * @param callback called with the port and a promise that resolves when /finish is called once the server is ready, the server will close when the callback completes
+ * Creates an HTTP server which responds with zeroes
+ * @param callback called with the port once the server is ready, the server will close when the callback completes
  * @param numIterations write zeroes into response every iteration
  * @param bytesPerIteration number of bytes to respond with on each iteration
  * @param msForCompleteResponse approximate number of milliseconds the response should take
  */
 export async function withZeroesHTTPServer(
-  callback: (port: number, finished: PromiseLike<void>) => Promise<any>,
+  callback: (port: number) => Promise<any>,
   numIterations = 100,
   bytesPerIteration = 1024,
   msForCompleteResponse = 5000
 ): Promise<void> {
-  const finished = new ResolvablePromise<void>();
-  const server = http.createServer(async (req, res) => {
-    const { url } = req;
-    switch (url) {
-      case '/zeroes':
-        res.writeHead(200, 'OK', { 'Content-Length': `${bytesPerIteration * numIterations}` });
-        for (let i = 0; i < numIterations; ++i) {
-          await sleep(msForCompleteResponse / numIterations);
-          res.write(Buffer.alloc(bytesPerIteration));
-        }
-        res.end();
-        break;
-      case '/finish':
-        finished.resolve(undefined);
-        res.writeHead(200, 'OK', { 'Content-Length': '2' });
-        res.write('OK');
-        res.end();
-        break;
+  const server = http.createServer(async (_req, res) => {
+    res.writeHead(200, 'OK', { 'Content-Length': `${bytesPerIteration * numIterations}` });
+    for (let i = 0; i < numIterations; ++i) {
+      await sleep(msForCompleteResponse / numIterations);
+      res.write(Buffer.alloc(bytesPerIteration));
     }
+    res.end();
   });
   server.listen();
   const addr = server.address();
@@ -41,7 +28,7 @@ export async function withZeroesHTTPServer(
     throw new Error('Unexpected server address type');
   }
   try {
-    await callback(addr.port, finished);
+    await callback(addr.port);
   } finally {
     server.close();
   }

--- a/packages/worker/src/activity.ts
+++ b/packages/worker/src/activity.ts
@@ -3,17 +3,17 @@ import { ActivityFunction } from '@temporalio/workflow';
 import { DataConverter } from '@temporalio/workflow/commonjs/converter/data-converter';
 import { coresdk } from '@temporalio/proto';
 import { asyncLocalStorage } from '@temporalio/activity/lib/internals';
-import { Context, CancellationError } from '@temporalio/activity';
+import { Context, CancellationError, Info } from '@temporalio/activity';
 
 export class Activity {
   protected cancelRequested = false;
-  public readonly context;
+  public readonly context: Context;
   public cancel: (reason?: any) => void = () => undefined;
   public readonly abortController: AbortController = new AbortController();
 
   // TODO: get all of the atributes required for setting the ActivityContext
   constructor(
-    public readonly id: string,
+    public readonly info: Info,
     protected readonly fn: ActivityFunction<any[], any>,
     protected readonly args: any[],
     public readonly dataConverter: DataConverter,
@@ -26,7 +26,7 @@ export class Activity {
         reject(new CancellationError(reason));
       };
     });
-    this.context = new Context(promise, this.abortController.signal, this.heartbeatCallback);
+    this.context = new Context(info, promise, this.abortController.signal, this.heartbeatCallback);
     promise.catch(() => undefined);
   }
 

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -789,11 +789,12 @@ function extractActivityInfo(
   activityNamespace: string
 ): ActivityInfo {
   // NOTE: We trust core to supply all of these fields instead of checking for null and undefined everywhere
+  const { taskToken, activityId } = task as NonNullableObject<coresdk.activity_task.IActivityTask>;
   const start = task.start as NonNullableObject<coresdk.activity_task.IStart>;
   const activityType = JSON.parse(start.activityType);
   return {
-    taskToken: task.taskToken!,
-    activityId: task.activityId!,
+    taskToken,
+    activityId,
     workflowExecution: start.workflowExecution as NonNullableObject<coresdk.common.WorkflowExecution>,
     attempt: start.attempt,
     isLocal,

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -764,7 +764,8 @@ export class Worker {
       )
         .pipe(
           tap({
-            error: () => {
+            error: (error) => {
+              this.log.error('Worker failed', { error });
               this.state = 'FAILED';
             },
           })


### PR DESCRIPTION
## Why?
- Activity Info was missing
- Cancellation tests are less flakey with signals than with timeouts
-
## Checklist

1. Closes issue: 

2. How was this tested:

3. Any docs updates needed?
Documented the Activity Info interface