### PR TITLE
Handle errors returned from core correctly

### DIFF
--- a/packages/activity/src/index.ts
+++ b/packages/activity/src/index.ts
@@ -165,7 +165,7 @@ export class Context {
    *
    * If an Activity times out, the last value of details is included in the ActivityTimeoutException delivered to a Workflow. Then the Workflow can pass the details to the next Activity invocation. This acts as a periodic checkpoint mechanism for the progress of an Activity.
    */
-  public readonly heartbeat: (details: any) => void;
+  public readonly heartbeat: (details?: any) => void;
 
   /**
    * **Not** meant to instantiated by Activity code, used by the worker.
@@ -176,7 +176,7 @@ export class Context {
     info: Info,
     cancelled: Promise<never>,
     cancellationSignal: AbortSignal,
-    heartbeat: (details: any) => void
+    heartbeat: (details?: any) => void
   ) {
     this.info = info;
     this.cancelled = cancelled;

--- a/packages/test/src/mock-native-worker.ts
+++ b/packages/test/src/mock-native-worker.ts
@@ -161,7 +161,7 @@ export class Worker extends RealWorker {
   }
 }
 
-export function makeDefaultWorker() {
+export function makeDefaultWorker(): Worker {
   return new Worker({
     workflowsPath: `${__dirname}/../../test-workflows/lib`,
     activitiesPath: `${__dirname}/../../test-activities/lib`,

--- a/packages/test/src/mock-native-worker.ts
+++ b/packages/test/src/mock-native-worker.ts
@@ -9,6 +9,7 @@ import {
   WorkerOptions,
   compileWorkerOptions,
   addDefaults,
+  errors,
 } from '@temporalio/worker/lib/worker';
 import { sleep } from '@temporalio/worker/lib/utils';
 
@@ -49,8 +50,8 @@ export class MockNativeWorker implements NativeWorkerLike {
   }
 
   public async shutdown(): Promise<void> {
-    this.activityTasks.unshift(Promise.reject(new Error('Core is shut down')));
-    this.workflowActivations.unshift(Promise.reject(new Error('Core is shut down')));
+    this.activityTasks.unshift(Promise.reject(new errors.ShutdownError('Core is shut down')));
+    this.workflowActivations.unshift(Promise.reject(new errors.ShutdownError('Core is shut down')));
   }
 
   public async pollWorkflowActivation(): Promise<ArrayBuffer> {

--- a/packages/test/src/test-worker-activities.ts
+++ b/packages/test/src/test-worker-activities.ts
@@ -4,7 +4,7 @@ import { v4 as uuid4 } from 'uuid';
 import { coresdk } from '@temporalio/proto';
 import { defaultDataConverter } from '@temporalio/workflow/commonjs/converter/data-converter';
 import { httpGet } from '../../test-activities/lib';
-import { Worker } from './mock-native-worker';
+import { Worker, makeDefaultWorker } from './mock-native-worker';
 import { withZeroesHTTPServer } from './zeroes-http-server';
 
 export interface Context {
@@ -22,12 +22,8 @@ export async function runWorker(t: ExecutionContext<Context>, fn: () => Promise<
 }
 
 test.beforeEach((t) => {
-  const worker = new Worker({
-    activitiesPath: `${__dirname}/../../test-activities/lib`,
-    taskQueue: 'test',
-  });
   t.context = {
-    worker,
+    worker: makeDefaultWorker(),
   };
 });
 

--- a/packages/test/src/test-worker-error-handling.ts
+++ b/packages/test/src/test-worker-error-handling.ts
@@ -1,0 +1,94 @@
+import anyTest, { TestInterface } from 'ava';
+import Long from 'long';
+import { BehaviorSubject, Subject } from 'rxjs';
+import { first, take, tap, toArray } from 'rxjs/operators';
+import { v4 as uuid4 } from 'uuid';
+import { errors } from '@temporalio/worker';
+import { coresdk } from '@temporalio/proto';
+import { msToTs } from '@temporalio/workflow/commonjs/time';
+import { Worker, makeDefaultWorker } from './mock-native-worker';
+
+export interface Context {
+  worker: Worker;
+  feedbackSubject: Subject<coresdk.workflow_activation.WFActivation>;
+  numInFlightActivationsSubject: BehaviorSubject<number>;
+  numRunningWorkflowInstancesSubject: BehaviorSubject<number>;
+}
+
+export const test = anyTest as TestInterface<Context>;
+
+test.beforeEach((t) => {
+  t.context = {
+    worker: makeDefaultWorker(),
+    feedbackSubject: new Subject(),
+    numInFlightActivationsSubject: new BehaviorSubject(0),
+    numRunningWorkflowInstancesSubject: new BehaviorSubject(0),
+  };
+});
+
+function makeStartWorkflowActivation(runId: string) {
+  return {
+    taskToken: new Uint8Array([0, 1, 2, 3]),
+    runId,
+    timestamp: msToTs(10),
+    jobs: [
+      coresdk.workflow_activation.WFActivationJob.create({
+        startWorkflow: {
+          workflowId: 'wfid',
+          arguments: [],
+          workflowType: 'sleep',
+          randomnessSeed: new Long(3),
+        },
+      }),
+    ],
+  };
+}
+
+test('Worker handles WorkflowError in pollWorkflowActivation correctly', async (t) => {
+  const { worker, feedbackSubject, numInFlightActivationsSubject, numRunningWorkflowInstancesSubject } = t.context;
+  const p = worker.runWorkflows(feedbackSubject, numInFlightActivationsSubject, numRunningWorkflowInstancesSubject);
+  const runId = uuid4();
+  const [numInFlightActivations, numRunningWorkflowInstances] = await Promise.all([
+    numInFlightActivationsSubject.pipe(take(5), toArray()).toPromise(),
+    numRunningWorkflowInstancesSubject.pipe(take(3), toArray()).toPromise(),
+    (async () => {
+      await worker.native.runWorkflowActivation(makeStartWorkflowActivation(runId));
+      worker.native.emitWorkflowError(new errors.WorkflowError('Something bad happened', runId, 'details'));
+    })(),
+  ]);
+  t.deepEqual(numInFlightActivations, [0, 1, 0, 1, 0]);
+  t.deepEqual(numRunningWorkflowInstances, [0, 1, 0]);
+  worker.shutdown();
+  // Catch the ShutdownError to avoid unhandled rejection
+  await t.throwsAsync(() => worker.native.pollActivityTask(), { instanceOf: errors.ShutdownError });
+  await p;
+});
+
+test('Worker handles WorkflowError in completeWorkflowActivation correctly', async (t) => {
+  const { worker, feedbackSubject, numInFlightActivationsSubject, numRunningWorkflowInstancesSubject } = t.context;
+  const p = worker.runWorkflows(feedbackSubject, numInFlightActivationsSubject, numRunningWorkflowInstancesSubject);
+  const runId = uuid4();
+  worker.native.completeWorkflowActivation = () => {
+    return Promise.reject(new errors.WorkflowError('Something bad happened', runId, 'details'));
+  };
+  const promises = Promise.all([
+    numInFlightActivationsSubject.pipe(take(3), toArray()).toPromise(),
+    numRunningWorkflowInstancesSubject.pipe(take(3), toArray()).toPromise(),
+    feedbackSubject
+      .pipe(
+        tap((activation) => console.log('feedback', activation)),
+        first()
+      )
+      .toPromise(),
+  ]);
+  worker.native.emit({
+    workflow: makeStartWorkflowActivation(runId),
+  });
+  const [numInFlightActivations, numRunningWorkflowInstances] = await promises;
+  t.deepEqual(numInFlightActivations, [0, 1, 0]);
+  t.deepEqual(numRunningWorkflowInstances, [0, 1, 0]);
+  worker.shutdown();
+  // Catch the ShutdownError to avoid unhandled rejection
+  await t.throwsAsync(() => worker.native.pollActivityTask(), { instanceOf: errors.ShutdownError });
+  await p;
+});

--- a/packages/test/src/test-worker-error-handling.ts
+++ b/packages/test/src/test-worker-error-handling.ts
@@ -1,7 +1,7 @@
 import anyTest, { TestInterface } from 'ava';
 import Long from 'long';
 import { BehaviorSubject, Subject } from 'rxjs';
-import { first, take, tap, toArray } from 'rxjs/operators';
+import { first, take, toArray } from 'rxjs/operators';
 import { v4 as uuid4 } from 'uuid';
 import { errors } from '@temporalio/worker';
 import { coresdk } from '@temporalio/proto';
@@ -77,12 +77,7 @@ test('Worker handles WorkflowError in completeWorkflowActivation correctly', asy
   const promises = Promise.all([
     numInFlightActivationsSubject.pipe(take(3), toArray()).toPromise(),
     numRunningWorkflowInstancesSubject.pipe(take(3), toArray()).toPromise(),
-    feedbackSubject
-      .pipe(
-        tap((activation) => console.log('feedback', activation)),
-        first()
-      )
-      .toPromise(),
+    feedbackSubject.pipe(first()).toPromise(),
   ]);
   worker.native.emit({
     workflow: makeStartWorkflowActivation(runId),

--- a/packages/test/src/test-worker-lifecycle.ts
+++ b/packages/test/src/test-worker-lifecycle.ts
@@ -4,7 +4,7 @@
  */
 import test from 'ava';
 import Long from 'long';
-import { Worker } from '@temporalio/worker';
+import { Worker, DefaultLogger } from '@temporalio/worker';
 import { sleep } from '@temporalio/worker/lib/utils';
 import { Worker as MockedWorker } from './mock-native-worker';
 import { RUN_INTEGRATION_TESTS } from './helpers';
@@ -63,6 +63,7 @@ test('Mocked worker suspends and resumes', async (t) => {
   const worker = new MockedWorker({
     shutdownGraceTime: '5ms',
     taskQueue: 'suspend-test',
+    logger: new DefaultLogger('DEBUG'),
   });
   const p = worker.run();
   t.is(worker.getState(), 'RUNNING');

--- a/packages/worker/native/Cargo.lock
+++ b/packages/worker/native/Cargo.lock
@@ -1142,6 +1142,7 @@ version = "0.1.0"
 dependencies = [
  "futures",
  "neon",
+ "once_cell",
  "prost",
  "prost-types",
  "temporal-sdk-core",

--- a/packages/worker/native/Cargo.toml
+++ b/packages/worker/native/Cargo.toml
@@ -16,9 +16,6 @@ neon = { version = "0.8.0", default-features = false, features = ["napi-4", "eve
 prost = "0.7"
 prost-types = "0.7"
 tokio = "1.4.0"
-
-[dependencies.temporal-sdk-core]
-# TODO: revert back to *, can't now because of this error: prerelease package needs to be specified explicitly
-# version = "*"
-version = "0.1.0-alpha.1"
-path = "./sdk-core"
+once_cell = "1.7.2"
+# TODO: revert back to version *, can't now because of this error: prerelease package needs to be specified explicitly
+temporal-sdk-core = { version = "0.1.0-alpha.1", path = "./sdk-core" }

--- a/packages/worker/native/index.d.ts
+++ b/packages/worker/native/index.d.ts
@@ -39,10 +39,12 @@ export interface WorkerOptions {
 
 export interface Worker {}
 
-export declare type PollCallback = (err?: Error, result: ArrayBuffer) => void;
-export declare type WorkerCallback = (err?: Error, result: Worker) => void;
-export declare type VoidCallback = (err?: Error, result: void) => void;
+export declare type PollCallback = (err: Error, result: ArrayBuffer) => void;
+export declare type WorkerCallback = (err: Error, result: Worker) => void;
+export declare type VoidCallback = (err: Error, result: void) => void;
 
+// TODO: improve type, for some reason Error is not accepted here
+export declare function registerErrors(errors: Record<string, any>): void;
 export declare function newWorker(workerOptions: WorkerOptions, callback: WorkerCallback): void;
 export declare function workerShutdown(worker: Worker, callback: VoidCallback): void;
 export declare function workerBreakLoop(worker: Worker, callback: VoidCallback): void;

--- a/packages/worker/native/src/errors.rs
+++ b/packages/worker/native/src/errors.rs
@@ -1,0 +1,92 @@
+use neon::prelude::*;
+use once_cell::sync::OnceCell;
+
+/// An unhandled error while communicating with the server, considered fatal
+pub static TRANSPORT_ERROR: OnceCell<Root<JsFunction>> = OnceCell::new();
+/// Thrown after shutdown was requested as a response to a poll function, JS should stop polling
+/// once this error is encountered
+pub static SHUTDOWN_ERROR: OnceCell<Root<JsFunction>> = OnceCell::new();
+/// Workflow did something Core did not expect, it should be immediately deleted from the cache
+pub static WORKFLOW_ERROR: OnceCell<Root<JsFunction>> = OnceCell::new();
+/// Something unexpected happened, considered fatal
+pub static UNEXPECTED_ERROR: OnceCell<Root<JsFunction>> = OnceCell::new();
+
+/// This is one of the ways to implement custom errors in neon.
+/// Taken from the answer in GitHub issues: https://github.com/neon-bindings/neon/issues/714
+pub trait CustomError {
+    fn construct<'a, C>(&self, cx: &mut C, args: Vec<Handle<JsValue>>) -> JsResult<'a, JsObject>
+    where
+        C: Context<'a>;
+
+    fn from_string<'a, C>(&self, cx: &mut C, message: String) -> JsResult<'a, JsObject>
+    where
+        C: Context<'a>;
+
+    fn from_error<'a, C, E>(&self, cx: &mut C, err: E) -> JsResult<'a, JsObject>
+    where
+        C: Context<'a>,
+        E: std::fmt::Display;
+}
+
+// Implement `CustomError` for ALL errors in a `OnceCell`. This only needs to be
+// done _once_ even if other errors are added.
+impl CustomError for OnceCell<Root<JsFunction>> {
+    fn construct<'a, C>(&self, cx: &mut C, args: Vec<Handle<JsValue>>) -> JsResult<'a, JsObject>
+    where
+        C: Context<'a>,
+    {
+        let error = self
+            .get()
+            .expect("Expected module to be initialized")
+            .to_inner(cx);
+
+        // Use `.construct` to call this as a constructor instead of a normal function
+        error.construct(cx, args)
+    }
+
+    fn from_string<'a, C>(&self, cx: &mut C, message: String) -> JsResult<'a, JsObject>
+    where
+        C: Context<'a>,
+    {
+        let args = vec![cx.string(message).upcast()];
+        self.construct(cx, args)
+    }
+
+    fn from_error<'a, C, E>(&self, cx: &mut C, err: E) -> JsResult<'a, JsObject>
+    where
+        C: Context<'a>,
+        E: std::fmt::Display,
+    {
+        self.from_string(cx, format!("{}", err))
+    }
+}
+
+/// This method should be manually called _once_ from JavaScript to initialize the module
+/// It expects a single argument, an object with the various Error constructors.
+/// This is a very common pattern in Neon modules.
+pub fn register_errors(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+    let mapping = cx.argument::<JsObject>(0)?;
+    let shutdown_error = mapping
+        .get(&mut cx, "ShutdownError")?
+        .downcast_or_throw::<JsFunction, FunctionContext>(&mut cx)?
+        .root(&mut cx);
+    let transport_error = mapping
+        .get(&mut cx, "TransportError")?
+        .downcast_or_throw::<JsFunction, FunctionContext>(&mut cx)?
+        .root(&mut cx);
+    let workflow_error = mapping
+        .get(&mut cx, "WorkflowError")?
+        .downcast_or_throw::<JsFunction, FunctionContext>(&mut cx)?
+        .root(&mut cx);
+    let unexpected_error = mapping
+        .get(&mut cx, "UnexpectedError")?
+        .downcast_or_throw::<JsFunction, FunctionContext>(&mut cx)?
+        .root(&mut cx);
+
+    TRANSPORT_ERROR.get_or_try_init(|| Ok(transport_error))?;
+    SHUTDOWN_ERROR.get_or_try_init(|| Ok(shutdown_error))?;
+    WORKFLOW_ERROR.get_or_try_init(|| Ok(workflow_error))?;
+    UNEXPECTED_ERROR.get_or_try_init(|| Ok(unexpected_error))?;
+
+    Ok(cx.undefined())
+}

--- a/packages/worker/native/src/errors.rs
+++ b/packages/worker/native/src/errors.rs
@@ -10,6 +10,8 @@ pub static SHUTDOWN_ERROR: OnceCell<Root<JsFunction>> = OnceCell::new();
 pub static WORKFLOW_ERROR: OnceCell<Root<JsFunction>> = OnceCell::new();
 /// Something unexpected happened, considered fatal
 pub static UNEXPECTED_ERROR: OnceCell<Root<JsFunction>> = OnceCell::new();
+/// Activity heartbeat can not sent, the Activity should be cancelled
+pub static ACTIVITY_HEARTBEAT_ERROR: OnceCell<Root<JsFunction>> = OnceCell::new();
 
 /// This is one of the ways to implement custom errors in neon.
 /// Taken from the answer in GitHub issues: https://github.com/neon-bindings/neon/issues/714
@@ -78,6 +80,10 @@ pub fn register_errors(mut cx: FunctionContext) -> JsResult<JsUndefined> {
         .get(&mut cx, "WorkflowError")?
         .downcast_or_throw::<JsFunction, FunctionContext>(&mut cx)?
         .root(&mut cx);
+    let activity_heartbeat_error = mapping
+        .get(&mut cx, "ActivityHeartbeatError")?
+        .downcast_or_throw::<JsFunction, FunctionContext>(&mut cx)?
+        .root(&mut cx);
     let unexpected_error = mapping
         .get(&mut cx, "UnexpectedError")?
         .downcast_or_throw::<JsFunction, FunctionContext>(&mut cx)?
@@ -86,6 +92,7 @@ pub fn register_errors(mut cx: FunctionContext) -> JsResult<JsUndefined> {
     TRANSPORT_ERROR.get_or_try_init(|| Ok(transport_error))?;
     SHUTDOWN_ERROR.get_or_try_init(|| Ok(shutdown_error))?;
     WORKFLOW_ERROR.get_or_try_init(|| Ok(workflow_error))?;
+    ACTIVITY_HEARTBEAT_ERROR.get_or_try_init(|| Ok(activity_heartbeat_error))?;
     UNEXPECTED_ERROR.get_or_try_init(|| Ok(unexpected_error))?;
 
     Ok(cx.undefined())

--- a/packages/worker/native/src/lib.rs
+++ b/packages/worker/native/src/lib.rs
@@ -1,10 +1,14 @@
-use neon::{prelude::*, register_module};
+mod errors;
+
+use errors::*;
+use neon::prelude::*;
 use prost::Message;
 use std::{fmt::Display, future::Future, sync::Arc, time::Duration};
 use temporal_sdk_core::{
     init, protos::coresdk::workflow_completion::WfActivationCompletion,
     protos::coresdk::ActivityHeartbeat, protos::coresdk::ActivityTaskCompletion, tracing_init,
-    Core, CoreInitOptions, ServerGatewayOptions, Url,
+    CompleteActivityError, CompleteWfError, Core, CoreInitError, CoreInitOptions,
+    PollActivityError, PollWfError, ServerGatewayOptions, Url,
 };
 use tokio::sync::mpsc::{channel, Sender};
 
@@ -79,28 +83,30 @@ where
 }
 
 /// Send an error to JS via callback using an [EventQueue]
-fn send_error<T>(queue: Arc<EventQueue>, callback: Root<JsFunction>, error: T)
+fn send_error<E, F>(queue: Arc<EventQueue>, callback: Root<JsFunction>, error_ctor: F)
 where
-    T: Display + Send + 'static,
+    E: Object,
+    F: for<'a> FnOnce(&mut TaskContext<'a>) -> JsResult<'a, E> + Send + 'static,
 {
     queue.send(move |mut cx| {
         let callback = callback.into_inner(&mut cx);
-        callback_with_error(&mut cx, callback, error)
+        callback_with_error(&mut cx, callback, error_ctor)
     });
 }
 
 /// Call [callback] with given error
-fn callback_with_error<'a, T>(
-    cx: &mut impl Context<'a>,
+fn callback_with_error<'a, C, E, F>(
+    cx: &mut C,
     callback: Handle<JsFunction>,
-    error: T,
+    error_ctor: F,
 ) -> NeonResult<()>
 where
-    T: Display + Send + 'static,
+    C: Context<'a>,
+    E: Object,
+    F: FnOnce(&mut C) -> JsResult<'a, E> + Send + 'static,
 {
     let this = cx.undefined();
-    // TODO: create better JS error types
-    let error = JsError::error(cx, format!("{}", error))?;
+    let error = error_ctor(cx)?;
     let result = cx.undefined();
     let args: Vec<Handle<JsValue>> = vec![error.upcast(), result.upcast()];
     callback.call(cx, this, args)?;
@@ -109,17 +115,24 @@ where
 
 /// When Future completes, call given JS callback using a neon::EventQueue with either error or
 /// undefined
-async fn void_future_to_js<E, F>(queue: Arc<EventQueue>, callback: Root<JsFunction>, f: F) -> ()
+async fn void_future_to_js<E, F, ER, EF>(
+    queue: Arc<EventQueue>,
+    callback: Root<JsFunction>,
+    f: F,
+    error_function: EF,
+) -> ()
 where
     E: Display + Send + 'static,
     F: Future<Output = Result<(), E>> + Send + 'static,
+    ER: Object,
+    EF: for<'a> FnOnce(&mut TaskContext<'a>, E) -> JsResult<'a, ER> + Send + 'static,
 {
     match f.await {
         Ok(()) => {
             send_result(queue, callback, |cx| Ok(cx.undefined()));
         }
         Err(err) => {
-            send_error(queue, callback, err);
+            send_error(queue, callback, |cx| error_function(cx, err));
         }
     }
 }
@@ -142,7 +155,14 @@ fn start_bridge_loop(
         .block_on(async {
             match init(core_init_options).await {
                 Err(err) => {
-                    send_error(queue.clone(), callback, err);
+                    send_error(queue.clone(), callback, |cx| match err {
+                        CoreInitError::InvalidUri(_) => {
+                            Ok(JsError::type_error(cx, "Invalid URI")?.upcast())
+                        }
+                        CoreInitError::TonicTransportError(err) => {
+                            TRANSPORT_ERROR.from_error(cx, err)
+                        }
+                    });
                 }
                 Ok(result) => {
                     send_result(
@@ -160,12 +180,17 @@ fn start_bridge_loop(
 
                         match request {
                             Request::Shutdown { callback } => {
-                                tokio::spawn(void_future_to_js(queue, callback, async move {
-                                    core.shutdown().await;
-                                    // Wrap the empty result in a valid Result object
-                                    let result: Result<(), String> = Ok(());
-                                    result
-                                }));
+                                tokio::spawn(void_future_to_js(
+                                    queue,
+                                    callback,
+                                    async move {
+                                        core.shutdown().await;
+                                        // Wrap the empty result in a valid Result object
+                                        let result: Result<(), String> = Ok(());
+                                        result
+                                    },
+                                    |cx, err| UNEXPECTED_ERROR.from_error(cx, err),
+                                ));
                             }
                             Request::BreakLoop { callback } => {
                                 send_result(queue, callback, |cx| Ok(cx.undefined()));
@@ -185,25 +210,60 @@ fn start_bridge_loop(
                                 completion,
                                 callback,
                             } => {
-                                tokio::spawn(void_future_to_js(queue, callback, async move {
-                                    core.complete_workflow_task(completion).await
-                                }));
+                                tokio::spawn(void_future_to_js(
+                                    queue,
+                                    callback,
+                                    async move { core.complete_workflow_task(completion).await },
+                                    |cx, err| match err {
+                                        CompleteWfError::WorkflowUpdateError { run_id, source } => {
+                                            let args = vec![
+                                                cx.string("Workflow update error").upcast(),
+                                                cx.string(run_id).upcast(),
+                                                cx.string(format!("{}", source)).upcast(),
+                                            ];
+                                            WORKFLOW_ERROR.construct(cx, args)
+                                        }
+                                        CompleteWfError::TonicError(_) => {
+                                            TRANSPORT_ERROR.from_error(cx, err)
+                                        }
+                                        CompleteWfError::MalformedWorkflowCompletion {
+                                            reason,
+                                            ..
+                                        } => Ok(JsError::type_error(cx, reason)?.upcast()),
+                                    },
+                                ));
                             }
                             Request::CompleteActivityTask {
                                 completion,
                                 callback,
                             } => {
-                                tokio::spawn(void_future_to_js(queue, callback, async move {
-                                    core.complete_activity_task(completion).await
-                                }));
+                                tokio::spawn(void_future_to_js(
+                                    queue,
+                                    callback,
+                                    async move { core.complete_activity_task(completion).await },
+                                    |cx, err| match err {
+                                        CompleteActivityError::MalformedActivityCompletion {
+                                            reason,
+                                            ..
+                                        } => Ok(JsError::type_error(cx, reason)?.upcast()),
+                                        CompleteActivityError::TonicError(_) => {
+                                            TRANSPORT_ERROR.from_error(cx, err)
+                                        }
+                                    },
+                                ));
                             }
                             Request::RecordActivityHeartbeat {
                                 heartbeat,
                                 callback,
                             } => {
-                                tokio::spawn(void_future_to_js(queue, callback, async move {
-                                    core.record_activity_heartbeat(heartbeat).await
-                                }));
+                                tokio::spawn(void_future_to_js(
+                                    queue,
+                                    callback,
+                                    async move { core.record_activity_heartbeat(heartbeat).await },
+                                    // TODO: refine these error types once core exposes them
+                                    // correctly
+                                    |cx, err| UNEXPECTED_ERROR.from_error(cx, err),
+                                ));
                             }
                         }
                     }
@@ -233,7 +293,22 @@ async fn handle_poll_workflow_activation_request(
             });
         }
         Err(err) => {
-            send_error(queue, callback, err);
+            send_error(queue, callback, move |cx| match err {
+                PollWfError::ShutDown => SHUTDOWN_ERROR.from_error(cx, err),
+                PollWfError::WorkflowUpdateError { run_id, source } => {
+                    let args = vec![
+                        cx.string("Workflow update error").upcast(),
+                        cx.string(run_id).upcast(),
+                        cx.string(format!("{}", source)).upcast(),
+                    ];
+                    WORKFLOW_ERROR.construct(cx, args)
+                }
+                PollWfError::BadPollResponseFromServer(_) => {
+                    UNEXPECTED_ERROR.from_error(cx, "Bad poll response from server")
+                }
+                PollWfError::AutocompleteError(_) => UNEXPECTED_ERROR.from_error(cx, err),
+                PollWfError::TonicError(_) => TRANSPORT_ERROR.from_error(cx, err),
+            });
         }
     }
 }
@@ -259,7 +334,10 @@ async fn handle_poll_activity_task_request(
             });
         }
         Err(err) => {
-            send_error(queue, callback, err);
+            send_error(queue, callback, |cx| match err {
+                PollActivityError::ShutDown => SHUTDOWN_ERROR.from_error(cx, err),
+                PollActivityError::TonicError(_) => TRANSPORT_ERROR.from_error(cx, err),
+            });
         }
     }
 }
@@ -340,7 +418,7 @@ fn worker_break_loop(mut cx: FunctionContext) -> JsResult<JsUndefined> {
         callback: callback.root(&mut cx),
     };
     if let Err(err) = worker.sender.blocking_send(request) {
-        callback_with_error(&mut cx, callback, err)?;
+        callback_with_error(&mut cx, callback, |cx| UNEXPECTED_ERROR.from_error(cx, err))?;
     };
     Ok(cx.undefined())
 }
@@ -354,7 +432,7 @@ fn worker_poll_workflow_activation(mut cx: FunctionContext) -> JsResult<JsUndefi
         callback: callback.root(&mut cx),
     };
     if let Err(err) = worker.sender.blocking_send(request) {
-        callback_with_error(&mut cx, callback, err)?;
+        callback_with_error(&mut cx, callback, |cx| UNEXPECTED_ERROR.from_error(cx, err))?;
     }
     Ok(cx.undefined())
 }
@@ -368,7 +446,7 @@ fn worker_poll_activity_task(mut cx: FunctionContext) -> JsResult<JsUndefined> {
         callback: callback.root(&mut cx),
     };
     if let Err(err) = worker.sender.blocking_send(request) {
-        callback_with_error(&mut cx, callback, err)?;
+        callback_with_error(&mut cx, callback, |cx| UNEXPECTED_ERROR.from_error(cx, err))?;
     }
     Ok(cx.undefined())
 }
@@ -388,10 +466,12 @@ fn worker_complete_workflow_activation(mut cx: FunctionContext) -> JsResult<JsUn
                 callback: callback.root(&mut cx),
             };
             if let Err(err) = worker.sender.blocking_send(request) {
-                callback_with_error(&mut cx, callback, err)?;
+                callback_with_error(&mut cx, callback, |cx| UNEXPECTED_ERROR.from_error(cx, err))?;
             };
         }
-        Err(_) => callback_with_error(&mut cx, callback, "Cannot decode Completion from buffer")?,
+        Err(_) => callback_with_error(&mut cx, callback, |cx| {
+            JsError::type_error(cx, "Cannot decode Completion from buffer")
+        })?,
     };
     Ok(cx.undefined())
 }
@@ -411,10 +491,12 @@ fn worker_complete_activity_task(mut cx: FunctionContext) -> JsResult<JsUndefine
                 callback: callback.root(&mut cx),
             };
             if let Err(err) = worker.sender.blocking_send(request) {
-                callback_with_error(&mut cx, callback, err)?;
+                callback_with_error(&mut cx, callback, |cx| UNEXPECTED_ERROR.from_error(cx, err))?;
             };
         }
-        Err(_) => callback_with_error(&mut cx, callback, "Cannot decode Completion from buffer")?,
+        Err(_) => callback_with_error(&mut cx, callback, |cx| {
+            JsError::type_error(cx, "Cannot decode Completion from buffer")
+        })?,
     };
     Ok(cx.undefined())
 }
@@ -434,14 +516,12 @@ fn worker_record_activity_heartbeat(mut cx: FunctionContext) -> JsResult<JsUndef
                 callback: callback.root(&mut cx),
             };
             if let Err(err) = worker.sender.blocking_send(request) {
-                callback_with_error(&mut cx, callback, err)?;
+                callback_with_error(&mut cx, callback, |cx| UNEXPECTED_ERROR.from_error(cx, err))?;
             };
         }
-        Err(_) => callback_with_error(
-            &mut cx,
-            callback,
-            "Cannot decode ActivityHeartbeat from buffer",
-        )?,
+        Err(_) => callback_with_error(&mut cx, callback, |cx| {
+            JsError::type_error(cx, "Cannot decode ActivityHeartbeat from buffer")
+        })?,
     };
     Ok(cx.undefined())
 }
@@ -460,7 +540,9 @@ fn worker_shutdown(mut cx: FunctionContext) -> JsResult<JsUndefined> {
     }
 }
 
-register_module!(mut cx, {
+#[neon::main]
+fn main(mut cx: ModuleContext) -> NeonResult<()> {
+    cx.export_function("registerErrors", errors::register_errors)?;
     cx.export_function("newWorker", worker_new)?;
     cx.export_function("workerShutdown", worker_shutdown)?;
     cx.export_function("workerBreakLoop", worker_break_loop)?;
@@ -479,4 +561,4 @@ register_module!(mut cx, {
         worker_record_activity_heartbeat,
     )?;
     Ok(())
-});
+}

--- a/packages/worker/scripts/build-rust.js
+++ b/packages/worker/scripts/build-rust.js
@@ -24,13 +24,21 @@ const platformMapping = { darwin: 'apple-darwin', linux: 'unknown-linux-gnu', wi
 
 function compile(target) {
   console.log('Compiling bridge', { target });
+  const out = target ? `releases/${target}/index.node` : 'index.node';
+  try {
+    fs.rmSync(out);
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      throw err;
+    }
+  }
   const { status, error } = spawnSync(
     'cargo-cp-artifact',
     [
       '--artifact',
       'cdylib',
       'temporal_sdk_node_bridge',
-      ...(target ? [`releases/${target}/index.node`] : ['index.node']),
+      out,
       '--',
       'cargo',
       'build',

--- a/packages/worker/scripts/build-rust.js
+++ b/packages/worker/scripts/build-rust.js
@@ -26,7 +26,7 @@ function compile(target) {
   console.log('Compiling bridge', { target });
   const out = target ? `releases/${target}/index.node` : 'index.node';
   try {
-    fs.rmSync(out);
+    fs.unlinkSync(out);
   } catch (err) {
     if (err.code !== 'ENOENT') {
       throw err;

--- a/packages/worker/src/errors.ts
+++ b/packages/worker/src/errors.ts
@@ -30,3 +30,10 @@ export class WorkflowError extends Error {
 export class UnexpectedError extends Error {
   public readonly name = 'UnexpectedError';
 }
+
+/**
+ * Thrown from JS if Worker does not shutdown in configured period
+ */
+export class GracefulShutdownPeriodExpiredError extends Error {
+  public readonly name = 'GracefulShutdownPeriodExpiredError';
+}

--- a/packages/worker/src/errors.ts
+++ b/packages/worker/src/errors.ts
@@ -32,6 +32,13 @@ export class UnexpectedError extends Error {
 }
 
 /**
+ * Activity heartbeat can not be sent, the activity should be cancelled
+ */
+export class ActivityHeartbeatError extends Error {
+  public readonly name = 'ActivityHeartbeatError';
+}
+
+/**
  * Thrown from JS if Worker does not shutdown in configured period
  */
 export class GracefulShutdownPeriodExpiredError extends Error {

--- a/packages/worker/src/errors.ts
+++ b/packages/worker/src/errors.ts
@@ -1,0 +1,32 @@
+/**
+ * An unhandled error while communicating with the server, considered fatal
+ */
+export class ShutdownError extends Error {
+  public readonly name = 'ShutdownError';
+}
+
+/**
+ * Thrown after shutdown was requested as a response to a poll function, JS should stop polling
+ * once this error is encountered
+ */
+export class TransportError extends Error {
+  public readonly name = 'TransportError';
+}
+
+/**
+ * Workflow did something Core did not expect, it should be immediately deleted from the cache
+ */
+export class WorkflowError extends Error {
+  public readonly name = 'WorkflowError';
+
+  public constructor(message: string, public readonly runId: string, public readonly source: string) {
+    super(message);
+  }
+}
+
+/**
+ * Something unexpected happened, considered fatal
+ */
+export class UnexpectedError extends Error {
+  public readonly name = 'UnexpectedError';
+}

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -18,5 +18,6 @@ export {
   ServerOptions,
   DataConverter,
   RetryOptions,
+  errors,
 } from './worker';
 export * from './logger';

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -439,7 +439,7 @@ export class Worker {
    */
   public suspendPolling(): void {
     if (this.state !== 'RUNNING') {
-      throw new Error('Not running');
+      throw new IllegalStateError('Not running');
     }
     this.state = 'SUSPENDED';
   }
@@ -449,7 +449,7 @@ export class Worker {
    */
   public resumePolling(): void {
     if (this.state !== 'SUSPENDED') {
-      throw new Error('Not suspended');
+      throw new IllegalStateError('Not suspended');
     }
     this.state = 'RUNNING';
   }
@@ -466,7 +466,7 @@ export class Worker {
    */
   shutdown(): void {
     if (this.state !== 'RUNNING' && this.state !== 'SUSPENDED') {
-      throw new Error('Not running and not suspended');
+      throw new IllegalStateError('Not running and not suspended');
     }
     this.state = 'STOPPING';
     this.nativeWorker.shutdown().then(() => {
@@ -517,7 +517,7 @@ export class Worker {
           default:
             // transition to DRAINING | FAILED happens only when an error occurs
             // in which case this observable would be closed
-            throw new Error(`Unexpected state ${state}`);
+            throw new IllegalStateError(`Unexpected state ${state}`);
         }
       }),
       repeat(),
@@ -542,7 +542,7 @@ export class Worker {
               | { type: 'run'; activity: Activity };
             const { taskToken, variant, activityId } = task;
             if (!variant) {
-              throw new Error('Got an activity task without a "variant" attribute');
+              throw new TypeError('Got an activity task without a "variant" attribute');
             }
 
             switch (variant) {
@@ -661,7 +661,7 @@ export class Worker {
                 if (maybeStartWorkflow !== undefined) {
                   const attrs = maybeStartWorkflow.startWorkflow;
                   if (!(attrs && attrs.workflowId && attrs.workflowType && attrs.randomnessSeed)) {
-                    throw new Error(
+                    throw new TypeError(
                       `Expected StartWorkflow with workflowId, workflowType and randomnessSeed, got ${JSON.stringify(
                         maybeStartWorkflow
                       )}`
@@ -687,7 +687,9 @@ export class Worker {
                   )(attrs.workflowType);
                   await workflow.registerImplementation(scriptName);
                 } else {
-                  throw new Error('Received workflow activation for an untracked workflow with no start workflow job');
+                  throw new IllegalStateError(
+                    'Received workflow activation for an untracked workflow with no start workflow job'
+                  );
                 }
               } catch (error) {
                 this.log.error('Failed to create a workflow', { taskToken, runId: task.runId, error });
@@ -777,7 +779,7 @@ export class Worker {
 
   protected workflow$(): Observable<void> {
     if (this.options.taskQueue === undefined) {
-      throw new Error('Worker taskQueue not defined');
+      throw new TypeError('Worker taskQueue not defined');
     }
 
     // Used to send back cache evictions when completing an activation with a WorkflowError
@@ -875,7 +877,7 @@ export class Worker {
    */
   async run(): Promise<void> {
     if (this.state !== 'INITIALIZED') {
-      throw new Error('Poller was aleady started');
+      throw new IllegalStateError('Poller was aleady started');
     }
     this.state = 'RUNNING';
 

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -889,7 +889,7 @@ export class Worker {
     );
   }
 
-  protected setupShutdownHook() {
+  protected setupShutdownHook(): void {
     const startShutdownSequence = () => {
       for (const signal of this.options.shutdownSignals) {
         process.off(signal, startShutdownSequence);

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -646,6 +646,7 @@ export class Worker {
             const close = jobs.length < task.jobs.length;
             task.jobs = jobs;
             if (jobs.length === 0) {
+              workflow?.isolate.dispose();
               if (!close) {
                 throw new IllegalStateError('Got a Workflow activation with no jobs');
               }


### PR DESCRIPTION
## What was changed:
- Heartbeat details is now an optional parameter
- Use typed errors for errors returned from Core
- Add error handling for errors returned from Core
- Add worker State types: `DRAINING | DRAINED`
- Fix isolates not being disposed on `removeFromCache` activations
- Always delete index.node before building rust code

## Checklist

1. Closes #51 

2. How was this tested:
Added tests for the added error handling.

3. Any docs updates needed?
Only docstrings