### PR TITLE
Create a bench test and stress the worker

### DIFF
--- a/packages/test/src/bench.ts
+++ b/packages/test/src/bench.ts
@@ -1,0 +1,129 @@
+import path from 'path';
+import arg from 'arg';
+import { range } from 'rxjs';
+import { mergeMap, take, tap, withLatestFrom } from 'rxjs/operators';
+import { Worker, DefaultLogger } from '@temporalio/worker';
+import { Connection } from '@temporalio/client';
+import { msStrToTs } from '@temporalio/workflow/commonjs/time';
+import * as opentelemetry from '@opentelemetry/sdk-node';
+import { JaegerExporter } from '@opentelemetry/exporter-jaeger';
+
+async function waitOnNamespace(connection: Connection, namespace: string, maxAttempts = 100, retryIntervalSecs = 1) {
+  for (let attempt = 1; attempt <= maxAttempts; ++attempt) {
+    try {
+      await connection.service.getWorkflowExecutionHistory({
+        namespace,
+        execution: { workflowId: 'fake', runId: '12345678-1234-1234-1234-1234567890ab' },
+      });
+    } catch (err) {
+      if (err.details === 'Requested workflow history not found, may have passed retention period.') {
+        break;
+      }
+      if (attempt === maxAttempts) {
+        throw err;
+      }
+      await new Promise((resolve) => setTimeout(resolve, retryIntervalSecs * 1000));
+    }
+  }
+}
+
+async function runCancelTestWorkflow(connection: Connection, name: string, taskQueue: string) {
+  const workflow = connection.workflow<any>(name, { taskQueue });
+  await workflow.start();
+}
+
+function toMB(bytes: number, fractionDigits = 2) {
+  return (bytes / 1024 / 1024).toFixed(fractionDigits);
+}
+
+async function runWorkflows(
+  worker: Worker,
+  connection: Connection,
+  name: string,
+  taskQueue: string,
+  numWorkflows: number,
+  concurrency: number,
+  heapSampleIteration = 20
+) {
+  let numComplete = 0;
+  await range(0, numWorkflows)
+    .pipe(
+      take(numWorkflows),
+      mergeMap(() => runCancelTestWorkflow(connection, name, taskQueue), concurrency),
+      withLatestFrom(worker.numInFlightActivations$, worker.numRunningWorkflowInstances$),
+      tap(([_, numInFlightActivations, numRunningWorkflowInstances]) => {
+        ++numComplete;
+        console.log(
+          `Workflow complete (${numComplete}/${numWorkflows}) (in flight - WFs: ${numRunningWorkflowInstances}, activations: ${numInFlightActivations})`
+        );
+        if (numComplete % heapSampleIteration === 0) {
+          const { heapUsed, heapTotal } = process.memoryUsage();
+          console.log(`🔵 heap used / total MB: ${toMB(heapUsed)} / ${toMB(heapTotal)})`);
+        }
+      })
+    )
+    .toPromise();
+}
+async function main() {
+  const args = arg({
+    '--iterations': Number,
+    '--workflow': String,
+    '--max-concurrent-activity-executions': Number,
+    '--max-concurrent-wft-executions': Number,
+    '--concurrent-wf-clients': Number,
+    '--log-level': String,
+  });
+  const workflowName = args['--workflow'] || 'cancel-fake-progress';
+  const iterations = args['--iterations'] || 1000;
+  const maxConcurrentActivityExecutions = args['--max-concurrent-activity-executions'] || 100;
+  const maxConcurrentWorkflowTaskExecutions = args['--max-concurrent-wft-executions'] || 10;
+  const concurrentWFClients = args['--concurrent-wf-clients'] || 100;
+  const logLevel = (args['--log-level'] || 'INFO').toUpperCase();
+
+  // In order for JaegerExporter to transmit packets correctly, increase net.inet.udp.maxdgram to 65536.
+  // See: https://github.com/jaegertracing/jaeger-client-node/issues/124#issuecomment-324222456
+  const jaegerExporter = new JaegerExporter({
+    serviceName: 'bench',
+  });
+  const otel = new opentelemetry.NodeSDK({
+    traceExporter: jaegerExporter,
+  });
+  await otel.start();
+  const namespace = `bench-${new Date().toISOString()}`;
+  const taskQueue = 'bench';
+  const connection = new Connection(undefined, { namespace });
+
+  await connection.service.registerNamespace({ namespace, workflowExecutionRetentionPeriod: msStrToTs('1 day') });
+  console.log('Registered namespace', { namespace });
+  await waitOnNamespace(connection, namespace);
+  console.log('Wait complete on namespace', { namespace });
+
+  const worker = await Worker.create({
+    workflowsPath: path.join(__dirname, '../../test-workflows/lib'),
+    activitiesPath: path.join(__dirname, '../../test-activities/lib'),
+    taskQueue,
+    maxConcurrentActivityExecutions,
+    maxConcurrentWorkflowTaskExecutions,
+    logger: new DefaultLogger(logLevel as any),
+    serverOptions: {
+      namespace,
+    },
+  });
+  console.log('Created worker');
+
+  await Promise.all([
+    (async () => {
+      await worker.run();
+      await otel.shutdown();
+    })(),
+    (async () => {
+      await runWorkflows(worker, connection, workflowName, taskQueue, iterations, concurrentWFClients);
+      worker.shutdown();
+    })(),
+  ]);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/test/src/test-integration.ts
+++ b/packages/test/src/test-integration.ts
@@ -78,22 +78,25 @@ if (RUN_INTEGRATION_TESTS) {
     t.is(res, 'Hello, world!');
   });
 
-  const testCancelHTTPRequest = async (t: ExecutionContext<Context>, waitForActivityCancelled: boolean) => {
+  test('cancel-fake-progress', async (t) => {
+    const client = new Connection();
+    const workflow = client.workflow<Empty>('cancel-fake-progress', { taskQueue: 'test' });
+    await workflow.start();
+    t.pass();
+  });
+
+  test("cancel-http-request don't waitForActivityCancelled", async (t) => {
     await withZeroesHTTPServer(async (port, finished) => {
       const client = new Connection();
       const url = `http://127.0.0.1:${port}`;
       const workflow = client.workflow<CancellableHTTPRequest>('cancel-http-request', { taskQueue: 'test' });
-      await t.throwsAsync(() => workflow.start(url, waitForActivityCancelled), {
+      await t.throwsAsync(() => workflow.start(url, false), {
         message: 'Activity cancelled',
         instanceOf: WorkflowExecutionFailedError,
       });
       await finished;
     });
-  };
-
-  test('cancel-http-request waitForActivityCancelled', (t) => testCancelHTTPRequest(t, true));
-
-  test("cancel-http-request don't waitForActivityCancelled", (t) => testCancelHTTPRequest(t, false));
+  });
 
   test('activity-failure', async (t) => {
     const client = new Connection();

--- a/packages/test/src/test-worker-error-handling.ts
+++ b/packages/test/src/test-worker-error-handling.ts
@@ -7,9 +7,6 @@ import { errors } from '@temporalio/worker';
 import { ActivationWithContext } from '@temporalio/worker/lib/worker';
 import { coresdk } from '@temporalio/proto';
 import { msToTs } from '@temporalio/workflow/commonjs/time';
-import { ResolvablePromise } from '@temporalio/workflow/commonjs/common';
-import { defaultDataConverter } from '@temporalio/workflow/commonjs/converter/data-converter';
-import { Context as ActivityContext, CancellationError } from '@temporalio/activity';
 import { Worker, makeDefaultWorker } from './mock-native-worker';
 
 export interface Context {
@@ -85,44 +82,5 @@ test('Worker handles WorkflowError in completeWorkflowActivation correctly', asy
   worker.shutdown();
   // Catch the ShutdownError to avoid unhandled rejection
   await t.throwsAsync(() => worker.native.pollActivityTask(), { instanceOf: errors.ShutdownError });
-  await p;
-});
-
-test('Worker handles heartbeat errors correctly', async (t) => {
-  const { worker } = t.context;
-  const cancelled = new ResolvablePromise();
-  await worker.registerActivities({
-    test: {
-      async activity() {
-        const ctx = ActivityContext.current();
-        for (;;) {
-          ctx.heartbeat();
-          try {
-            await Promise.race([new Promise((resolve) => setTimeout(resolve, 10)), ctx.cancelled]);
-          } catch (err) {
-            if (err instanceof CancellationError) {
-              cancelled.resolve(undefined);
-            }
-            throw err;
-          }
-        }
-      },
-    },
-  });
-  const p = worker.run();
-  worker.native.recordActivityHeartbeat = () => {
-    throw new errors.ActivityHeartbeatError('This is a test');
-  };
-  await worker.native.runActivityTask({
-    taskToken: new Uint8Array([1, 2, 1, 3]),
-    activityId: 'abc',
-    start: {
-      activityType: JSON.stringify(['test', 'activity']),
-      input: defaultDataConverter.toPayloads(),
-    },
-  });
-  await cancelled;
-  worker.shutdown();
-  t.pass();
   await p;
 });

--- a/packages/worker/native/Cargo.lock
+++ b/packages/worker/native/Cargo.lock
@@ -1270,8 +1270,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.4.1"
-source = "git+https://github.com/temporalio/tonic#8cf821f1afedf715b15aff41a0d51601030c48cb"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac42cd97ac6bd2339af5bcabf105540e21e45636ec6fa6aae5e85d44db31be0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1310,9 +1311,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f715efe02c0862926eb463e49368d38ddb119383475686178e32e26d15d06a66"
+checksum = "bf0aa6dfc29148c3826708dabbfa83c121eeb84df4d1468220825e3a33651687"
 dependencies = [
  "futures-core",
  "futures-util",

--- a/packages/worker/native/src/errors.rs
+++ b/packages/worker/native/src/errors.rs
@@ -10,8 +10,6 @@ pub static SHUTDOWN_ERROR: OnceCell<Root<JsFunction>> = OnceCell::new();
 pub static WORKFLOW_ERROR: OnceCell<Root<JsFunction>> = OnceCell::new();
 /// Something unexpected happened, considered fatal
 pub static UNEXPECTED_ERROR: OnceCell<Root<JsFunction>> = OnceCell::new();
-/// Activity heartbeat can not sent, the Activity should be cancelled
-pub static ACTIVITY_HEARTBEAT_ERROR: OnceCell<Root<JsFunction>> = OnceCell::new();
 
 /// This is one of the ways to implement custom errors in neon.
 /// Taken from the answer in GitHub issues: https://github.com/neon-bindings/neon/issues/714
@@ -80,10 +78,6 @@ pub fn register_errors(mut cx: FunctionContext) -> JsResult<JsUndefined> {
         .get(&mut cx, "WorkflowError")?
         .downcast_or_throw::<JsFunction, FunctionContext>(&mut cx)?
         .root(&mut cx);
-    let activity_heartbeat_error = mapping
-        .get(&mut cx, "ActivityHeartbeatError")?
-        .downcast_or_throw::<JsFunction, FunctionContext>(&mut cx)?
-        .root(&mut cx);
     let unexpected_error = mapping
         .get(&mut cx, "UnexpectedError")?
         .downcast_or_throw::<JsFunction, FunctionContext>(&mut cx)?
@@ -92,7 +86,6 @@ pub fn register_errors(mut cx: FunctionContext) -> JsResult<JsUndefined> {
     TRANSPORT_ERROR.get_or_try_init(|| Ok(transport_error))?;
     SHUTDOWN_ERROR.get_or_try_init(|| Ok(shutdown_error))?;
     WORKFLOW_ERROR.get_or_try_init(|| Ok(workflow_error))?;
-    ACTIVITY_HEARTBEAT_ERROR.get_or_try_init(|| Ok(activity_heartbeat_error))?;
     UNEXPECTED_ERROR.get_or_try_init(|| Ok(unexpected_error))?;
 
     Ok(cx.undefined())

--- a/packages/worker/src/errors.ts
+++ b/packages/worker/src/errors.ts
@@ -32,13 +32,6 @@ export class UnexpectedError extends Error {
 }
 
 /**
- * Activity heartbeat can not be sent, the activity should be cancelled
- */
-export class ActivityHeartbeatError extends Error {
-  public readonly name = 'ActivityHeartbeatError';
-}
-
-/**
  * Thrown from JS if Worker does not shutdown in configured period
  */
 export class GracefulShutdownPeriodExpiredError extends Error {

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -704,7 +704,7 @@ export class Worker {
             const close = jobs.length < activation.jobs.length;
             activation.jobs = jobs;
             if (jobs.length === 0) {
-              workflow?.isolate.dispose();
+              workflow?.dispose();
               if (!close) {
                 const message = 'Got a Workflow activation with no jobs';
                 span.setStatus({ code: otel.SpanStatusCode.ERROR, message });
@@ -780,7 +780,7 @@ export class Worker {
                     },
                   }).finish();
                 }
-                workflow?.isolate.dispose();
+                workflow?.dispose();
                 span.setStatus({ code: otel.SpanStatusCode.ERROR, message: error.message });
                 return { state: undefined, output: { close: true, completion, span, parentSpan: root } };
               }

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -888,8 +888,7 @@ export class Worker {
     ).pipe(
       this.workflowOperator(),
       mergeMap(async ({ completion, parentSpan: root }) => {
-        const context = otel.setSpan(otel.context.active(), root);
-        const span = tracer.startSpan('complete', undefined, context);
+        const span = childSpan(root, 'complete');
         try {
           await this.nativeWorker.completeWorkflowActivation(completion.buffer.slice(completion.byteOffset));
           span.setStatus({ code: otel.SpanStatusCode.OK });

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -22,7 +22,6 @@ import {
   delay,
   filter,
   first,
-  groupBy,
   ignoreElements,
   map,
   mapTo,

--- a/packages/worker/src/workflow.ts
+++ b/packages/worker/src/workflow.ts
@@ -185,6 +185,7 @@ export class Workflow {
    * Do not use this Workflow instance after this method has been called.
    */
   public dispose(): void {
+    this.context.release();
     this.isolate.dispose();
   }
 }

--- a/packages/worker/src/workflow.ts
+++ b/packages/worker/src/workflow.ts
@@ -180,4 +180,12 @@ export class Workflow {
     const run = await registerWorkflow.namespace.get('run');
     await run.apply(undefined, [], {});
   }
+
+  /**
+   * Dispose of the isolate and context.
+   * Do not use this Workflow instance after this method has been called.
+   */
+  public dispose(): void {
+    this.isolate.dispose();
+  }
 }

--- a/packages/worker/src/workflow.ts
+++ b/packages/worker/src/workflow.ts
@@ -7,7 +7,7 @@ import * as internals from '@temporalio/workflow/commonjs/internals';
 import * as init from '@temporalio/workflow/commonjs/init';
 import { ActivityOptions, validateActivityOptions } from '@temporalio/workflow';
 import { Loader } from './loader';
-import { tracer } from './tracing';
+import { tracer, childSpan } from './tracing';
 
 export enum ApplyMode {
   ASYNC = 'apply',
@@ -54,8 +54,7 @@ export class Workflow {
     loader.overrideModule('protobufjs/minimal', protobufModule);
     let child: otel.Span | undefined = undefined;
     if (span) {
-      const context = otel.setSpan(otel.context.active(), span);
-      child = tracer.startSpan('load.protos.module', undefined, context);
+      child = childSpan(span, 'load.protos.module');
     }
     const protosModule = await loader.loadModule(require.resolve('@temporalio/proto/es2020/index.js'));
     if (child) {

--- a/packages/worker/src/workflow.ts
+++ b/packages/worker/src/workflow.ts
@@ -25,6 +25,9 @@ interface WorkflowModule {
   concludeActivation: ivm.Reference<typeof internals.concludeActivation>;
 }
 
+// Shared runtime module for all isolates, needs to be created in context.
+const runtimeModule = new ivm.NativeModule(require.resolve('../build/Release/temporalio-workflow-isolate-extension'));
+
 export class Workflow {
   private constructor(
     public readonly id: string,
@@ -44,9 +47,6 @@ export class Workflow {
     const isolate = new ivm.Isolate();
     const context = await isolate.createContext();
 
-    const runtimeModule = new ivm.NativeModule(
-      require.resolve('../build/Release/temporalio-workflow-isolate-extension')
-    );
     const runtime = await runtimeModule.create(context);
 
     const loader = new Loader(isolate, context);

--- a/packages/worker/src/workflow.ts
+++ b/packages/worker/src/workflow.ts
@@ -7,7 +7,7 @@ import * as internals from '@temporalio/workflow/commonjs/internals';
 import * as init from '@temporalio/workflow/commonjs/init';
 import { ActivityOptions, validateActivityOptions } from '@temporalio/workflow';
 import { Loader } from './loader';
-import { tracer, childSpan } from './tracing';
+import { childSpan } from './tracing';
 
 export enum ApplyMode {
   ASYNC = 'apply',


### PR DESCRIPTION
## What was changed:
- Created a bench test
- Update core
- Remove error handling for activity heartbeats

## Checklist

1. Closes issue:
Closes #79 

2. How was this tested:
Ran `bench.js` locally.

We've been running this bench script for over a week and fixing issues with both the node and core SDKs.
Results showed that we had a memory leak from creating modules which was an [isolated-vm issue](https://github.com/laverdet/isolated-vm/issues/243) and is resolved in branch `main`, new version was not yet published.
Compiling all of these modules is extremely slow (can reach a second when worker is busy), we should revisit this and perhaps switch to using a bundler and startup snapshots for isolates (a POC for that has been started in the `bundler` branch).