### PR TITLE
Add `ConnectionOptions.tls` and move `ConnectionOptions.namespace` to `WorkflowOptions`.

### DIFF
--- a/packages/create-project/samples/client-mtls-from-sample.ts
+++ b/packages/create-project/samples/client-mtls-from-sample.ts
@@ -1,7 +1,6 @@
 // @@@SNIPSTART nodejs-mtls-client
 import fs from 'fs';
 import path from 'path';
-import * as grpc from 'grpc';
 import { Connection } from '@temporalio/client';
 
 async function run() {
@@ -11,16 +10,15 @@ async function run() {
   if (certsDir === undefined) {
     throw new Error('Please pass certs dir as single argument');
   }
-  const credentials = grpc.credentials.createSsl(
-    fs.readFileSync(path.join(certsDir, 'cluster/ca/server-intermediate-ca.pem')),
-    fs.readFileSync(path.join(certsDir, 'client/development/client-development-namespace.key')),
-    fs.readFileSync(path.join(certsDir, 'client/development/client-development-namespace.pem'))
-  );
   // Connect to localhost and use the "default" namespace
   const connection = new Connection({
-    credentials,
-    channelArgs: {
-      'grpc.ssl_target_name_override': 'development.cluster-x.contoso.com',
+    tls: {
+      serverNameOverride: 'development.cluster-x.contoso.com',
+      serverRootCACertificate: fs.readFileSync(path.join(certsDir, 'cluster/ca/server-intermediate-ca.pem')),
+      clientCertPair: {
+        crt: fs.readFileSync(path.join(certsDir, 'client/development/client-development-namespace.pem')),
+        key: fs.readFileSync(path.join(certsDir, 'client/development/client-development-namespace.key')),
+      },
     },
   });
   await connection.untilReady();

--- a/packages/create-project/samples/client-mtls-from-sample.ts
+++ b/packages/create-project/samples/client-mtls-from-sample.ts
@@ -10,7 +10,7 @@ async function run() {
   if (certsDir === undefined) {
     throw new Error('Please pass certs dir as single argument');
   }
-  // Connect to localhost and use the "default" namespace
+  // Connect to localhost with TLS
   const connection = new Connection({
     tls: {
       serverNameOverride: 'development.cluster-x.contoso.com',

--- a/packages/create-project/samples/client.ts
+++ b/packages/create-project/samples/client.ts
@@ -3,9 +3,11 @@ import { Connection } from '@temporalio/client';
 import { Example } from '@interfaces/workflows';
 
 async function run() {
-  // Connect to localhost and use the "default" namespace
+  // Connect to localhost with default ConnectionOptions,
+  // pass options to the Connection constructor to configure TLS and other settings.
   const connection = new Connection();
-  // Create a typed client for the workflow defined above
+  // Create a typed client using the Example Workflow interface,
+  // Workflow will be started in the "default" namespace unless specified otherwise.
   const example = connection.workflow<Example>('example', { taskQueue: 'tutorial' });
   const result = await example.start('Temporal');
   console.log(result); // Hello, Temporal

--- a/packages/test-activities/src/index.ts
+++ b/packages/test-activities/src/index.ts
@@ -21,7 +21,7 @@ export async function waitForCancellation(): Promise<void> {
 
 async function signalSchedulingWorkflow(signalName: string) {
   const { info } = Context.current();
-  const connection = new Connection({ namespace: info.workflowNamespace });
+  const connection = new Connection();
   await connection.service.signalWorkflowExecution({
     namespace: info.workflowNamespace,
     workflowExecution: Context.current().info.workflowExecution,

--- a/packages/test/src/test-integration.ts
+++ b/packages/test/src/test-integration.ts
@@ -151,7 +151,7 @@ if (RUN_INTEGRATION_TESTS) {
     const res = await workflow.start();
     t.is(res, undefined);
     const execution = await client.service.getWorkflowExecutionHistory({
-      namespace: client.options.namespace,
+      namespace: workflow.options.namespace,
       execution: { workflowId: workflow.workflowId, runId: workflow.runId },
     });
     const timerEvents = execution.history!.events!.filter(({ eventType }) => timerEventTypes.has(eventType!));
@@ -167,7 +167,7 @@ if (RUN_INTEGRATION_TESTS) {
     const res = await workflow.start();
     t.is(res, undefined);
     const execution = await client.service.getWorkflowExecutionHistory({
-      namespace: client.options.namespace,
+      namespace: workflow.options.namespace,
       execution: { workflowId: workflow.workflowId, runId: workflow.runId },
     });
     const timerEvents = execution.history!.events!.filter(({ eventType }) => timerEventTypes.has(eventType!));
@@ -181,7 +181,7 @@ if (RUN_INTEGRATION_TESTS) {
     const res = await workflow.start();
     t.is(res, undefined);
     const execution = await client.service.getWorkflowExecutionHistory({
-      namespace: client.options.namespace,
+      namespace: workflow.options.namespace,
       execution: { workflowId: workflow.workflowId, runId: workflow.runId },
     });
     const timerEvents = execution.history!.events!.filter(({ eventType }) => timerEventTypes.has(eventType!));
@@ -199,7 +199,7 @@ if (RUN_INTEGRATION_TESTS) {
     const workflow = client.workflow<ArgsAndReturn>('args-and-return', { taskQueue: 'test' });
     await workflow.start('hey', undefined, Buffer.from('abc'));
     const execution = await client.service.getWorkflowExecutionHistory({
-      namespace: client.options.namespace,
+      namespace: workflow.options.namespace,
       execution: { workflowId: workflow.workflowId, runId: workflow.runId },
     });
     const events = execution.history!.events!.filter(

--- a/packages/worker/native/index.d.ts
+++ b/packages/worker/native/index.d.ts
@@ -1,3 +1,5 @@
+// NOTE: this interface is duplicated in the client module `packages/client/src/index.ts`
+
 /** TLS configuration options. */
 export interface TLSConfig {
   /**
@@ -46,7 +48,8 @@ export interface ServerOptions {
   /**
    * TLS configuration options.
    *
-   * If undefined will not connect using TLS, to connect with TLS without any customization, pass an empty object
+   * Pass undefined to use a non-encrypted connection or an empty object to
+   * connect with TLS without any customization.
    */
   tls?: TLSConfig;
 }


### PR DESCRIPTION
## What was changed
See commit messages

## Why?
Unify client and worker TLS configuration.
`namespace` in `ConnectionOptions` isn't used anywhere but `WorkflowClient` which is confusing behavior.

## Checklist

1. Closes issue: 

2. How was this tested:
Ran the client TLS sample locally.

3. Any docs updates needed?
I'll update the documentation site soon.
