### PR TITLE
chore(core): Update core in prep for sticky execution

### DIFF
--- a/packages/test/src/mock-native-worker.ts
+++ b/packages/test/src/mock-native-worker.ts
@@ -108,7 +108,6 @@ export class MockNativeWorker implements NativeWorkerLike {
   public async runWorkflowActivation(
     activation: coresdk.workflow_activation.IWFActivation
   ): Promise<coresdk.workflow_completion.WFActivationCompletion> {
-    activation = { ...activation, taskToken: activation.taskToken ?? Buffer.from(uuid4()) };
     const arr = coresdk.workflow_activation.WFActivation.encode(activation).finish();
     const buffer = arr.buffer.slice(arr.byteOffset, arr.byteOffset + arr.byteLength);
     const result = await new Promise<ArrayBuffer>((resolve) => {

--- a/packages/worker/native/index.d.ts
+++ b/packages/worker/native/index.d.ts
@@ -54,12 +54,21 @@ export interface ServerOptions {
   tls?: TLSConfig;
 }
 
-export interface WorkerOptions {
+/**
+ * Configure a Core instance
+ */
+export interface CoreOptions {
   /**
    * Options for communicating with the Temporal server
    */
   serverOptions: ServerOptions;
+  /**
+   * Maximum number of Workflow instances to cache before automatic eviction
+   */
+  maxCachedWorkflows: number;
+}
 
+export interface WorkerOptions {
   /**
    * The task queue the worker will pull from
    */
@@ -72,14 +81,17 @@ export interface WorkerOptions {
 }
 
 export interface Worker {}
+export interface Core {}
 
 export declare type PollCallback = (err: Error, result: ArrayBuffer) => void;
 export declare type WorkerCallback = (err: Error, result: Worker) => void;
+export declare type CoreCallback = (err: Error, result: Core) => void;
 export declare type VoidCallback = (err: Error, result: void) => void;
 
 // TODO: improve type, for some reason Error is not accepted here
 export declare function registerErrors(errors: Record<string, any>): void;
-export declare function newWorker(workerOptions: WorkerOptions, callback: WorkerCallback): void;
+export declare function newCore(coreOptions: CoreOptions, callback: CoreCallback): void;
+export declare function newWorker(core: Core, workerOptions: WorkerOptions, callback: WorkerCallback): void;
 export declare function workerShutdown(worker: Worker, callback: VoidCallback): void;
 export declare function workerBreakLoop(worker: Worker, callback: VoidCallback): void;
 export declare function workerPollWorkflowActivation(worker: Worker, callback: PollCallback): void;

--- a/packages/workflow/src/init.ts
+++ b/packages/workflow/src/init.ts
@@ -64,6 +64,7 @@ export function overrideGlobals(): void {
 export function initWorkflow(
   workflow: Workflow,
   workflowId: string,
+  runId: string,
   randomnessSeed: number[],
   taskQueue: string,
   isolateExtension: IsolateExtension
@@ -76,6 +77,7 @@ export function initWorkflow(
 
   state.workflow = workflow;
   state.workflowId = workflowId;
+  state.runId = runId;
   state.random = alea(randomnessSeed);
   state.taskQueue = taskQueue;
   state.isolateExtension = isolateExtension;

--- a/packages/workflow/src/internals.ts
+++ b/packages/workflow/src/internals.ts
@@ -272,6 +272,10 @@ export class State {
    */
   public workflowId?: string;
   /**
+   * The run ID of the current Workflow
+   */
+  public runId?: string;
+  /**
    * The task queue of the current executing Workflow, used as a default when scheudling activities
    */
   public taskQueue?: string;
@@ -335,11 +339,11 @@ function idToSeq(id: string | undefined | null) {
   return parseInt(id);
 }
 
-export function concludeActivation(taskToken: Uint8Array): Uint8Array {
-  const { commands } = state;
+export function concludeActivation(): Uint8Array {
+  const { commands, runId } = state;
   // TODO: activation failed (should this be done in main node isolate?)
   const encoded = coresdk.workflow_completion.WFActivationCompletion.encodeDelimited({
-    taskToken,
+    runId,
     successful: { commands },
   }).finish();
   state.commands = [];


### PR DESCRIPTION
## What was changed

Updated the core submodule and made some of the preparations for sticky execution.

**NOTE**: We still do not support sharing a single core between multiple workers, I'll work on that in one of the next PRs.

## Why?
Keep up with upstream core changes

## Checklist

2. How was this tested:
Standard test suite

3. Any docs updates needed?
Not ATM
