### PR TITLE
fix: Fix cross compilation of rust code

### DIFF
--- a/packages/core-bridge/package.json
+++ b/packages/core-bridge/package.json
@@ -5,7 +5,8 @@
   "main": "index.node",
   "types": "index.d.ts",
   "scripts": {
-    "build": "TEMPORAL_WORKER_FORCE_BUILD=true node ./scripts/build.js",
+    "build-rust": "TEMPORAL_WORKER_FORCE_BUILD=true node ./scripts/build.js",
+    "build": "npm run build-rust",
     "install": "node ./scripts/build.js"
   },
   "keywords": [


### PR DESCRIPTION
Noticed that rust is not being cross compiled anymore and the latest published version does not include the pre-built binaries.
This is a regression introduced in #128.