### PR TITLE
feat(client): Implement signalWithStart

### DIFF
--- a/packages/client/src/interceptors.ts
+++ b/packages/client/src/interceptors.ts
@@ -28,6 +28,16 @@ export interface WorkflowSignalInput {
   readonly workflowExecution: WorkflowExecution;
 }
 
+/** Input for WorkflowClientCallsInterceptor.signalWithStart */
+export interface WorkflowSignalWithStartInput {
+  readonly workflowName: string;
+  readonly workflowArgs: unknown[];
+  readonly signalName: string;
+  readonly signalArgs: unknown[];
+  readonly headers: Headers;
+  readonly options: CompiledWorkflowOptions;
+}
+
 /** Input for WorkflowClientCallsInterceptor.query */
 export interface WorkflowQueryInput {
   readonly queryType: string;
@@ -52,13 +62,38 @@ export interface WorkflowCancelInput {
  * Implement any of these methods to intercept WorkflowClient outbound calls
  */
 export interface WorkflowClientCallsInterceptor {
+  /**
+   * Intercept a service call to startWorkflowExecution
+   *
+   * If you implement this method,
+   * {@link signalWithStart} most likely needs to be implemented too
+   */
   start?: (input: WorkflowStartInput, next: Next<this, 'start'>) => Promise<string /* runId */>;
+  /**
+   * Intercept a service call to signalWorkflowExecution
+   *
+   * If you implement this method,
+   * {@link signalWithStart} most likely needs to be implemented too
+   */
   signal?: (input: WorkflowSignalInput, next: Next<this, 'signal'>) => Promise<void>;
+  /**
+   * Intercept a service call to signalWithStartWorkflowExecution
+   */
+  signalWithStart?: (input: WorkflowSignalWithStartInput, next: Next<this, 'signalWithStart'>) => Promise<string>;
+  /**
+   * Intercept a service call to queryWorkflow
+   */
   query?: (input: WorkflowQueryInput, next: Next<this, 'query'>) => Promise<unknown>;
+  /**
+   * Intercept a service call to terminateWorkflowExecution
+   */
   terminate?: (
     input: WorkflowTerminateInput,
     next: Next<this, 'terminate'>
   ) => Promise<TerminateWorkflowExecutionResponse>;
+  /**
+   * Intercept a service call to requestCancelWorkflowExecution
+   */
   cancel?: (input: WorkflowCancelInput, next: Next<this, 'cancel'>) => Promise<RequestCancelWorkflowExecutionResponse>;
 }
 

--- a/packages/client/src/workflow-options.ts
+++ b/packages/client/src/workflow-options.ts
@@ -1,7 +1,6 @@
 import ms from 'ms';
 import { v4 as uuid4 } from 'uuid';
 import { msToTs } from '@temporalio/workflow/lib/time';
-import { Headers } from '@temporalio/workflow';
 import * as iface from '@temporalio/proto';
 
 // Copied from https://github.com/temporalio/sdk-java/blob/master/temporal-sdk/src/main/java/io/temporal/client/WorkflowOptions.java
@@ -97,8 +96,6 @@ export type CompiledWorkflowOptions = BaseWorkflowOptions &
     workflowExecutionTimeout?: iface.google.protobuf.IDuration;
     workflowRunTimeout?: iface.google.protobuf.IDuration;
     workflowTaskTimeout?: iface.google.protobuf.IDuration;
-    /** headers are only added to CompiledWorkflowOptions because they're supposed to be injected by interceptors */
-    headers: Headers;
   };
 
 /**
@@ -124,6 +121,5 @@ export function compileWorkflowOptions({
     workflowExecutionTimeout: workflowExecutionTimeout ? msToTs(ms(workflowExecutionTimeout)) : undefined,
     workflowRunTimeout: workflowRunTimeout ? msToTs(ms(workflowRunTimeout)) : undefined,
     workflowTaskTimeout: workflowTaskTimeout ? msToTs(ms(workflowTaskTimeout)) : undefined,
-    headers: new Map(),
   };
 }


### PR DESCRIPTION
Closes #153

Also removes some `console.log` statements that somehow made their way into `main` and ensures all calls to `start` go through interceptors.