### PR TITLE
fix(docs): Add typescript dep

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -24,7 +24,8 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "typedoc": "^0.20.35",
-    "typedoc-plugin-markdown": "^3.7.1"
+    "typedoc-plugin-markdown": "^3.7.1",
+    "typescript": "^4.2.3"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Why?

Before making this change, when running `npm run docs`, I got `Warning: You are running with an unsupported TypeScript version! TypeDoc supports 3.9, 4.0, 4.1, 4.2` followed by an error:

<details>

```sh
sdk-node git:(upstream ⚡ patch-2) 1≡ $ nr docs

> typescript-sdk@ docs /Users/me/gh/sdk-node
> lerna run --stream build-docs

lerna notice cli v4.0.0
lerna info versioning independent
lerna info Executing command in 1 package: "npm run build-docs"
@temporalio/docs: > @temporalio/docs@0.1.3 build-docs /Users/me/gh/sdk-node/packages/docs
@temporalio/docs: > TYPEDOC_WATCH=false DOCUSAURUS_NO_DUPLICATE_TITLE_WARNING=false docusaurus build
@temporalio/docs: [en] Creating an optimized production build...
@temporalio/docs: Warning: You are running with an unsupported TypeScript version! TypeDoc supports 3.9, 4.0, 4.1, 4.2
@temporalio/docs: (node:97416) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'kind' of undefined
@temporalio/docs:     at Object.isDeclaration (/Users/me/gh/sdk-node/node_modules/typescript/lib/typescript.js:13449:18)
@temporalio/docs:     at Object.isDeclarationName (/Users/me/gh/sdk-node/node_modules/typescript/lib/typescript.js:16414:75)
@temporalio/docs:     at getTypeOfSymbolAtLocation (/Users/me/gh/sdk-node/node_modules/typescript/lib/typescript.js:66929:20)
@temporalio/docs:     at Object.getTypeOfSymbolAtLocation (/Users/me/gh/sdk-node/node_modules/typescript/lib/typescript.js:45163:35)
@temporalio/docs:     at Object.convertProperty (/Users/me/gh/sdk-node/packages/docs/node_modules/typedoc/dist/lib/converter/symbols.js:330:176)
@temporalio/docs:     at convertSymbol (/Users/me/gh/sdk-node/packages/docs/node_modules/typedoc/dist/lib/converter/symbols.js:80:79)
@temporalio/docs:     at Object.convertClassOrInterface (/Users/me/gh/sdk-node/packages/docs/node_modules/typedoc/dist/lib/converter/symbols.js:245:13)
@temporalio/docs:     at convertSymbol (/Users/me/gh/sdk-node/packages/docs/node_modules/typedoc/dist/lib/converter/symbols.js:80:79)
@temporalio/docs:     at Object.convertAlias (/Users/me/gh/sdk-node/packages/docs/node_modules/typedoc/dist/lib/converter/symbols.js:380:9)
@temporalio/docs:     at convertSymbol (/Users/me/gh/sdk-node/packages/docs/node_modules/typedoc/dist/lib/converter/symbols.js:80:79)
@temporalio/docs:     at convertSymbols (/Users/me/gh/sdk-node/packages/docs/node_modules/typedoc/dist/lib/converter/symbols.js:86:9)
@temporalio/docs:     at Object.convertNamespace (/Users/me/gh/sdk-node/packages/docs/node_modules/typedoc/dist/lib/converter/symbols.js:118:5)
@temporalio/docs:     at convertSymbol (/Users/me/gh/sdk-node/packages/docs/node_modules/typedoc/dist/lib/converter/symbols.js:80:79)
@temporalio/docs:     at Object.convertAlias (/Users/me/gh/sdk-node/packages/docs/node_modules/typedoc/dist/lib/converter/symbols.js:380:9)
@temporalio/docs:     at Object.convertSymbol (/Users/me/gh/sdk-node/packages/docs/node_modules/typedoc/dist/lib/converter/symbols.js:80:79)
@temporalio/docs:     at Converter.convertReExports (/Users/me/gh/sdk-node/packages/docs/node_modules/typedoc/dist/lib/converter/converter.js:188:23)
@temporalio/docs: (Use `node --trace-warnings ...` to show where the warning was created)
@temporalio/docs: (node:97416) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
@temporalio/docs: (node:97416) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
@temporalio/docs: ℹ Compiling Client
@temporalio/docs: ℹ Compiling Server
@temporalio/docs: ✔ Client: Compiled successfully in 5.10s
@temporalio/docs: ✔ Server: Compiled successfully in 6.40s
@temporalio/docs: error building locale=en
@temporalio/docs: Error: Docusaurus found broken links!
@temporalio/docs: Please check the pages of your site in the list below, and make sure you don't reference any path that does not exist.
@temporalio/docs: Note: it's possible to ignore broken links with the 'onBrokenLinks' Docusaurus configuration, and let the build pass.
@temporalio/docs: Exhaustive list of all broken links found:
@temporalio/docs: - On source page path = /:
@temporalio/docs:    -> linking to ./api/modules/worker (resolved as: /api/modules/worker)
@temporalio/docs:    -> linking to ./api/modules/workflow (resolved as: /api/modules/workflow)
@temporalio/docs:    -> linking to ./api/modules/activity (resolved as: /api/modules/activity)
@temporalio/docs:    -> linking to ./api/modules/client (resolved as: /api/modules/client)
@temporalio/docs:    -> linking to ./api/modules/proto (resolved as: /api/modules/proto)
@temporalio/docs:     at Object.reportMessage (/Users/me/gh/sdk-node/packages/docs/node_modules/@docusaurus/utils/lib/index.js:383:19)
@temporalio/docs:     at Object.handleBrokenLinks (/Users/me/gh/sdk-node/packages/docs/node_modules/@docusaurus/core/lib/server/brokenLinks.js:142:17)
@temporalio/docs:     at async buildLocale (/Users/me/gh/sdk-node/packages/docs/node_modules/@docusaurus/core/lib/commands/build.js:162:5)
@temporalio/docs:     at async tryToBuildLocale (/Users/me/gh/sdk-node/packages/docs/node_modules/@docusaurus/core/lib/commands/build.js:31:28)
@temporalio/docs:     at async Object.mapAsyncSequencial (/Users/me/gh/sdk-node/packages/docs/node_modules/@docusaurus/utils/lib/index.js:338:24)
@temporalio/docs:     at async build (/Users/me/gh/sdk-node/packages/docs/node_modules/@docusaurus/core/lib/commands/build.js:69:25)
@temporalio/docs: npm ERR! code ELIFECYCLE
@temporalio/docs: npm ERR! errno 1
@temporalio/docs: npm ERR! @temporalio/docs@0.1.3 build-docs: `TYPEDOC_WATCH=false DOCUSAURUS_NO_DUPLICATE_TITLE_WARNING=false docusaurus build`
@temporalio/docs: npm ERR! Exit status 1
@temporalio/docs: npm ERR! 
@temporalio/docs: npm ERR! Failed at the @temporalio/docs@0.1.3 build-docs script.
@temporalio/docs: npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
@temporalio/docs: npm ERR! A complete log of this run can be found in:
@temporalio/docs: npm ERR!     /Users/me/.npm/_logs/2021-08-10T03_21_26_877Z-debug.log
lerna ERR! npm run build-docs exited 1 in '@temporalio/docs'
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! typescript-sdk@ docs: `lerna run --stream build-docs`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the typescript-sdk@ docs script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/me/.npm/_logs/2021-08-10T03_21_26_918Z-debug.log
```

</details>

After this change, `npm run docs` succeeded.