### PR TITLE
feat!: Use CancelledFailure everywhere for cancellation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11533,6 +11533,7 @@
       }
     },
     "packages/activity": {
+      "name": "@temporalio/activity",
       "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
@@ -11540,6 +11541,7 @@
       }
     },
     "packages/client": {
+      "name": "@temporalio/client",
       "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
@@ -11560,6 +11562,7 @@
       }
     },
     "packages/common": {
+      "name": "@temporalio/common",
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
@@ -11568,6 +11571,7 @@
       }
     },
     "packages/core-bridge": {
+      "name": "@temporalio/core-bridge",
       "version": "0.2.0",
       "hasInstallScript": true,
       "license": "MIT",
@@ -11577,6 +11581,7 @@
       }
     },
     "packages/create-project": {
+      "name": "@temporalio/create",
       "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
@@ -11593,6 +11598,7 @@
       "integrity": "sha512-4P8Zm2H+BRS+c/xX1LrHw0qKpEhdlZjLCgWy+d78T9vqa2Z2SiD2wMrYuWIAFy5IZUD7nnNXroRttz+0RzlrzQ=="
     },
     "packages/interceptors-opentelemetry": {
+      "name": "@temporalio/interceptors-opentelemetry",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -11605,10 +11611,12 @@
       }
     },
     "packages/meta": {
+      "name": "temporalio",
       "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@temporalio/client": "file:../client",
+        "@temporalio/common": "file:../common",
         "@temporalio/proto": "file:../proto",
         "@temporalio/worker": "file:../worker",
         "@temporalio/workflow": "file:../workflow"
@@ -11618,6 +11626,7 @@
       }
     },
     "packages/proto": {
+      "name": "@temporalio/proto",
       "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
@@ -11631,6 +11640,7 @@
       }
     },
     "packages/test": {
+      "name": "@temporalio/test",
       "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
@@ -11651,6 +11661,7 @@
       }
     },
     "packages/worker": {
+      "name": "@temporalio/worker",
       "version": "0.6.0",
       "hasInstallScript": true,
       "license": "MIT",
@@ -11685,6 +11696,7 @@
       }
     },
     "packages/workflow": {
+      "name": "@temporalio/workflow",
       "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
@@ -19918,6 +19930,7 @@
       "version": "file:packages/meta",
       "requires": {
         "@temporalio/client": "file:../client",
+        "@temporalio/common": "file:../common",
         "@temporalio/proto": "file:../proto",
         "@temporalio/worker": "file:../worker",
         "@temporalio/workflow": "file:../workflow"

--- a/packages/activity/src/index.ts
+++ b/packages/activity/src/index.ts
@@ -54,15 +54,6 @@ import { AbortSignal } from 'abort-controller';
 export const asyncLocalStorage = new AsyncLocalStorage<Context>();
 
 /**
- * Thrown in an Activity when the Activity is cancelled while awaiting {@link Context.cancelled}.
- *
- * The Activity must {@link Context.heartbeat | send heartbeats} in order to be cancellable.
- */
-export class CancelledError extends Error {
-  public readonly name: string = 'CancelledError';
-}
-
-/**
  * Holds information about the current executing Activity
  */
 export interface Info {
@@ -138,7 +129,7 @@ export class Context {
   /**
    * Await this promise in an Activity to get notified of cancellation.
    *
-   * This promise will never be resolved, it will only be rejected with a {@link CancelledError}.
+   * This promise will never be resolved, it will only be rejected with a {@link CancelledFailure}.
    */
   public readonly cancelled: Promise<never>;
   /**
@@ -151,6 +142,8 @@ export class Context {
    * Send a heartbeat from an Activity.
    *
    * If an Activity times out, the last value of details is included in the ActivityTimeoutException delivered to a Workflow. Then the Workflow can pass the details to the next Activity invocation. This acts as a periodic checkpoint mechanism for the progress of an Activity.
+   *
+   * The Activity must heartbeat in order to receive cancellation.
    */
   public readonly heartbeat: (details?: any) => void;
 

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -20,6 +20,7 @@ export {
   defaultDataConverter,
   ActivityFailure,
   ApplicationFailure,
+  ChildWorkflowFailure,
   CancelledFailure,
   ServerFailure,
   TemporalFailure,

--- a/packages/common/src/failure.ts
+++ b/packages/common/src/failure.ts
@@ -130,7 +130,7 @@ export class ApplicationFailure extends TemporalFailure {
 export class CancelledFailure extends TemporalFailure {
   public readonly name: string = 'CancelledFailure';
 
-  constructor(message: string | undefined, public readonly details: unknown[], cause?: Error) {
+  constructor(message: string | undefined, public readonly details: unknown[] = [], cause?: Error) {
     super(message, message, cause);
   }
 }
@@ -196,6 +196,12 @@ export class ActivityFailure extends TemporalFailure {
   }
 }
 
+/**
+ * Contains information about an child workflow failure. Always contains the original reason for the
+ * failure as its cause. For example if a child workflow was terminated the cause is {@link TerminatedFailure}.
+ *
+ * This exception is expected to be thrown only by the framework code.
+ */
 export class ChildWorkflowFailure extends TemporalFailure {
   public constructor(
     public readonly namespace: string | undefined,
@@ -257,6 +263,8 @@ export function cutoffStackTrace(stack?: string): string {
  */
 export async function errorToFailure(err: unknown, dataConverter: DataConverter): Promise<ProtoFailure> {
   if (err instanceof TemporalFailure) {
+    if (err.failure) return err.failure;
+
     const base = {
       message: err.originalMessage,
       stackTrace: cutoffStackTrace(err.stack),
@@ -299,7 +307,10 @@ export async function errorToFailure(err: unknown, dataConverter: DataConverter)
       return {
         ...base,
         canceledFailureInfo: {
-          details: err.details ? { payloads: await dataConverter.toPayloads(...err.details) } : undefined,
+          details:
+            err.details && err.details.length
+              ? { payloads: await dataConverter.toPayloads(...err.details) }
+              : undefined,
         },
       };
     }

--- a/packages/docs/docs/index.md
+++ b/packages/docs/docs/index.md
@@ -14,4 +14,5 @@ slug: /
 | [`@temporalio/workflow`](./api/modules/workflow)         | Workflow runtime library                                                                      |
 | [`@temporalio/activity`](./api/modules/activity)         | Access to current activity context                                                            |
 | [`@temporalio/client`](./api/modules/client)             | Communicate with the Temporal service for things like administration and scheduling workflows |
+| [`@temporalio/common`](./api/modules/common)             | Utility functions and class which can be used in both Workflow and non Workflow code          |
 | [`@temporalio/proto`](./api/modules/proto)               | Compiled protobuf definitions                                                                 |

--- a/packages/meta/package.json
+++ b/packages/meta/package.json
@@ -4,6 +4,7 @@
   "description": "Temporal.io SDK meta-package",
   "dependencies": {
     "@temporalio/client": "file:../client",
+    "@temporalio/common": "file:../common",
     "@temporalio/proto": "file:../proto",
     "@temporalio/worker": "file:../worker",
     "@temporalio/workflow": "file:../workflow"

--- a/packages/meta/src/index.ts
+++ b/packages/meta/src/index.ts
@@ -1,5 +1,6 @@
 export * as worker from '@temporalio/worker';
 export * as client from '@temporalio/client';
 export * as proto from '@temporalio/proto';
+export * as common from '@temporalio/common';
 export * as workflow from '@temporalio/workflow';
 export * as activity from '@temporalio/activity';

--- a/packages/meta/tsconfig.json
+++ b/packages/meta/tsconfig.json
@@ -5,7 +5,11 @@
     "outDir": "./lib",
     "rootDir": "./src"
   },
-  "references": [{ "path": "../workflow/tsconfig.json" }, { "path": "../activity/tsconfig.json" }],
+  "references": [
+    { "path": "../activity/tsconfig.json" },
+    { "path": "../worker/tsconfig.json" },
+    { "path": "../workflow/tsconfig.json" }
+  ],
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/packages/test/src/activities/fake-progress.ts
+++ b/packages/test/src/activities/fake-progress.ts
@@ -1,5 +1,6 @@
 // @@@SNIPSTART nodejs-activity-fake-progress
-import { Context, CancelledError } from '@temporalio/activity';
+import { Context } from '@temporalio/activity';
+import { CancelledFailure } from '@temporalio/common';
 
 export async function fakeProgress(sleepIntervalMs = 1000): Promise<void> {
   try {
@@ -9,7 +10,7 @@ export async function fakeProgress(sleepIntervalMs = 1000): Promise<void> {
       Context.current().heartbeat(progress);
     }
   } catch (err) {
-    if (err instanceof CancelledError) {
+    if (err instanceof CancelledFailure) {
       // Cleanup
     }
     throw err;

--- a/packages/test/src/test-worker-activities.ts
+++ b/packages/test/src/test-worker-activities.ts
@@ -120,7 +120,7 @@ test('Worker cancels activity and reports cancellation', async (t) => {
       cancel: {},
     });
     compareCompletion(t, completion.result, {
-      canceled: {},
+      cancelled: { failure: { source: 'NodeSDK', canceledFailureInfo: {} } },
     });
   });
 });
@@ -146,7 +146,7 @@ test('Activity Context AbortSignal cancels a fetch request', async (t) => {
         cancel: {},
       });
       compareCompletion(t, completion.result, {
-        canceled: {},
+        cancelled: { failure: { source: 'NodeSDK', canceledFailureInfo: {} } },
       });
       await finished;
     });

--- a/packages/test/src/workflows/cancel-activity-after-first-completion.ts
+++ b/packages/test/src/workflows/cancel-activity-after-first-completion.ts
@@ -4,7 +4,7 @@
  * @module
  */
 
-import { CancellationScope, CancelledError } from '@temporalio/workflow';
+import { CancellationScope, CancelledFailure } from '@temporalio/workflow';
 import { httpGet } from '@activities';
 
 export async function main(url: string): Promise<string[]> {
@@ -17,10 +17,10 @@ export async function main(url: string): Promise<string[]> {
   try {
     return await Promise.race([promise, CancellationScope.current().cancelRequested]);
   } catch (err) {
-    if (!(err instanceof CancelledError)) {
+    if (!(err instanceof CancelledFailure)) {
       throw err;
     }
     console.log('Workflow cancelled while waiting on non cancellable scope');
-    return promise;
+    return await promise;
   }
 }

--- a/packages/test/src/workflows/cancel-fake-progress.ts
+++ b/packages/test/src/workflows/cancel-fake-progress.ts
@@ -1,4 +1,4 @@
-import { ActivityCancellationType, Context, CancelledError, CancellationScope, Trigger } from '@temporalio/workflow';
+import { ActivityCancellationType, Context, CancellationScope, isCancellation, Trigger } from '@temporalio/workflow';
 import { ActivitySignalHandler } from '../interfaces';
 import * as activities from '@activities';
 
@@ -27,7 +27,7 @@ async function main(): Promise<void> {
     });
     throw new Error('Activity completed instead of being cancelled');
   } catch (err) {
-    if (!(err instanceof CancelledError)) {
+    if (!isCancellation(err)) {
       throw err;
     }
   }

--- a/packages/test/src/workflows/cancel-http-request.ts
+++ b/packages/test/src/workflows/cancel-http-request.ts
@@ -1,4 +1,4 @@
-import { ActivityCancellationType, Context, CancellationScope, CancelledError, Trigger } from '@temporalio/workflow';
+import { ActivityCancellationType, Context, CancellationScope, isCancellation, Trigger } from '@temporalio/workflow';
 import { CancellableHTTPRequest } from '../interfaces';
 import { cancellableFetch } from '@activities';
 
@@ -26,7 +26,7 @@ async function main(url: string): Promise<void> {
       await promise;
     });
   } catch (err) {
-    if (!(err instanceof CancelledError)) {
+    if (!isCancellation(err)) {
       throw err;
     }
   }

--- a/packages/test/src/workflows/cancel-requested-with-non-cancellable.ts
+++ b/packages/test/src/workflows/cancel-requested-with-non-cancellable.ts
@@ -3,7 +3,7 @@
  * Used in the documentation site.
  */
 // @@@SNIPSTART nodejs-cancel-requested-with-non-cancellable
-import { CancelledError, CancellationScope } from '@temporalio/workflow';
+import { CancelledFailure, CancellationScope } from '@temporalio/workflow';
 import { httpGetJSON } from '@activities';
 
 export async function main(url: string): Promise<any> {
@@ -13,7 +13,7 @@ export async function main(url: string): Promise<any> {
   try {
     result = await Promise.race([scope.cancelRequested, promise]);
   } catch (err) {
-    if (!(err instanceof CancelledError)) {
+    if (!(err instanceof CancelledFailure)) {
       throw err;
     }
     // Prevent Workflow from completing so Activity can complete

--- a/packages/test/src/workflows/cancel-timer-immediately-alternative-impl.ts
+++ b/packages/test/src/workflows/cancel-timer-immediately-alternative-impl.ts
@@ -4,16 +4,16 @@
  * Used in the documentation site.
  */
 // @@@SNIPSTART nodejs-cancel-a-timer-from-workflow-alternative-impl
-import { CancelledError, CancellationScope, sleep } from '@temporalio/workflow';
+import { CancelledFailure, CancellationScope, sleep } from '@temporalio/workflow';
 
 export async function main(): Promise<void> {
   try {
     const scope = new CancellationScope();
     const promise = scope.run(() => sleep(1));
     scope.cancel(); // <-- Cancel the timer created in scope
-    await promise; // <-- Throws CancelledError
+    await promise; // <-- Throws CancelledFailure
   } catch (e) {
-    if (e instanceof CancelledError) {
+    if (e instanceof CancelledFailure) {
       console.log('Timer cancelled 👍');
     } else {
       throw e; // <-- Fail the workflow

--- a/packages/test/src/workflows/cancel-timer-immediately.ts
+++ b/packages/test/src/workflows/cancel-timer-immediately.ts
@@ -3,7 +3,7 @@
  * Used in the documentation site.
  */
 // @@@SNIPSTART nodejs-cancel-a-timer-from-workflow
-import { CancelledError, CancellationScope, sleep } from '@temporalio/workflow';
+import { CancelledFailure, CancellationScope, sleep } from '@temporalio/workflow';
 import { Empty } from '../interfaces';
 
 async function main(): Promise<void> {
@@ -15,7 +15,7 @@ async function main(): Promise<void> {
       await promise; // <-- Promise must be awaited in order for `cancellable` to throw
     });
   } catch (e) {
-    if (e instanceof CancelledError) {
+    if (e instanceof CancelledFailure) {
       console.log('Timer cancelled 👍');
     } else {
       throw e; // <-- Fail the workflow

--- a/packages/test/src/workflows/cancel-timer-with-delay.ts
+++ b/packages/test/src/workflows/cancel-timer-with-delay.ts
@@ -1,4 +1,4 @@
-import { CancelledError, CancellationScope, sleep } from '@temporalio/workflow';
+import { CancelledFailure, CancellationScope, sleep } from '@temporalio/workflow';
 import { Empty } from '../interfaces';
 
 async function main(): Promise<void> {
@@ -8,7 +8,7 @@ async function main(): Promise<void> {
   try {
     await promise;
   } catch (e) {
-    if (e instanceof CancelledError) {
+    if (e instanceof CancelledFailure) {
       console.log('Timer cancelled 👍');
     } else {
       throw e;

--- a/packages/test/src/workflows/cancel-workflow.ts
+++ b/packages/test/src/workflows/cancel-workflow.ts
@@ -1,20 +1,20 @@
-import { CancellationScope, CancelledError } from '@temporalio/workflow';
+import { ActivityFailure, CancellationScope, CancelledFailure } from '@temporalio/workflow';
 import { httpGet } from '@activities';
 
 export async function main(url: string): Promise<string> {
   // By default timers and activities are automatically cancelled when the workflow is cancelled
-  // and will throw the original CancelledError
+  // and will throw the original CancelledFailure
   try {
     return await httpGet(url);
   } catch (e) {
-    if (!(e instanceof CancelledError)) {
+    if (!(e instanceof ActivityFailure && e.cause instanceof CancelledFailure)) {
       throw e;
     }
     try {
       // Activity throws because Workflow has been cancelled
       return await httpGet(url);
     } catch (e) {
-      if (!(e instanceof CancelledError)) {
+      if (!(e instanceof CancelledFailure)) {
         throw e;
       }
       // Activity is allowed to complete because it's in a non cancellable scope

--- a/packages/test/src/workflows/cancellation-scopes.ts
+++ b/packages/test/src/workflows/cancellation-scopes.ts
@@ -1,4 +1,4 @@
-import { CancelledError, CancellationScope, sleep } from '@temporalio/workflow';
+import { CancelledFailure, CancellationScope, sleep } from '@temporalio/workflow';
 
 function sleepAndLogCancellation(cancellationExpected: boolean) {
   return async () => {
@@ -6,7 +6,7 @@ function sleepAndLogCancellation(cancellationExpected: boolean) {
       await sleep(3);
     } catch (e) {
       // We still want to know the workflow was cancelled
-      if (e instanceof CancelledError) {
+      if (e instanceof CancelledFailure) {
         console.log(`Scope cancelled ${cancellationExpected ? '👍' : '👎'}`);
       }
       throw e;
@@ -28,7 +28,7 @@ export async function main(): Promise<void> {
     await p1;
     console.log('Exception was not propagated 👎');
   } catch (e) {
-    if (e instanceof CancelledError) {
+    if (e instanceof CancelledFailure) {
       console.log('Exception was propagated 👍');
     }
   }
@@ -40,7 +40,7 @@ export async function main(): Promise<void> {
     await CancellationScope.cancellable(sleepAndLogCancellation(true));
     console.log('Exception was not propagated 👎');
   } catch (e) {
-    if (e instanceof CancelledError) {
+    if (e instanceof CancelledFailure) {
       console.log('Exception was propagated 👍');
     }
   }

--- a/packages/test/src/workflows/handle-external-workflow-cancellation-while-activity-running.ts
+++ b/packages/test/src/workflows/handle-external-workflow-cancellation-while-activity-running.ts
@@ -4,14 +4,14 @@
  * Used in the documentation site.
  */
 // @@@SNIPSTART nodejs-handle-external-workflow-cancellation-while-activity-running
-import { CancelledError, CancellationScope } from '@temporalio/workflow';
+import { CancellationScope, isCancellation } from '@temporalio/workflow';
 import { httpPostJSON, cleanup } from '@activities';
 
 export async function main(url: string, data: any): Promise<void> {
   try {
     await httpPostJSON(url, data);
   } catch (err) {
-    if (err instanceof CancelledError) {
+    if (isCancellation(err)) {
       console.log('Workflow cancelled');
       // Cleanup logic must be in a nonCancellable scope
       // If we'd run cleanup outside of a nonCancellable scope it would've been cancelled

--- a/packages/test/src/workflows/nested-cancellation.ts
+++ b/packages/test/src/workflows/nested-cancellation.ts
@@ -1,5 +1,5 @@
 // @@@SNIPSTART nodejs-nested-cancellation-scopes
-import { CancelledError, CancellationScope } from '@temporalio/workflow';
+import { CancellationScope, isCancellation } from '@temporalio/workflow';
 import { setup, httpPostJSON, cleanup } from '@activities';
 
 export async function main(url: string): Promise<void> {
@@ -8,7 +8,7 @@ export async function main(url: string): Promise<void> {
     try {
       await CancellationScope.withTimeout(1000, () => httpPostJSON(url, { some: 'data' }));
     } catch (err) {
-      if (err instanceof CancelledError) {
+      if (isCancellation(err)) {
         await CancellationScope.nonCancellable(() => cleanup(url));
       }
       throw err;

--- a/packages/test/src/workflows/partial-shield.ts
+++ b/packages/test/src/workflows/partial-shield.ts
@@ -1,4 +1,4 @@
-import { CancelledError, CancellationScope, sleep } from '@temporalio/workflow';
+import { CancelledFailure, CancellationScope, sleep } from '@temporalio/workflow';
 
 export async function main(): Promise<void> {
   try {
@@ -13,7 +13,7 @@ export async function main(): Promise<void> {
       })(),
     ]);
   } catch (e) {
-    if (e instanceof CancelledError) {
+    if (e instanceof CancelledFailure) {
       console.log('Workflow cancelled');
     }
     // Let the shielded sleep be triggered before completion

--- a/packages/test/src/workflows/trigger-cancellation.ts
+++ b/packages/test/src/workflows/trigger-cancellation.ts
@@ -1,5 +1,5 @@
 // @@@SNIPSTART nodejs-blocked-workflow
-import { Trigger, CancelledError } from '@temporalio/workflow';
+import { Trigger, CancelledFailure } from '@temporalio/workflow';
 import { Blocked } from '../interfaces';
 
 const unblocked = new Trigger<void>();
@@ -16,7 +16,7 @@ async function main(): Promise<void> {
     await unblocked;
     console.log('Unblocked');
   } catch (err) {
-    if (!(err instanceof CancelledError)) {
+    if (!(err instanceof CancelledFailure)) {
       throw err;
     }
     console.log('Cancelled');

--- a/packages/test/src/workflows/workflow-cancellation-scenarios.ts
+++ b/packages/test/src/workflows/workflow-cancellation-scenarios.ts
@@ -1,11 +1,11 @@
-import { CancellationScope, CancelledError, sleep } from '@temporalio/workflow';
+import { CancellationScope, CancelledFailure, sleep } from '@temporalio/workflow';
 import { WorkflowCancellationScenarios } from '../interfaces';
 
 async function main(outcome: 'complete' | 'cancel' | 'fail', when: 'immediately' | 'after-cleanup'): Promise<void> {
   try {
     await CancellationScope.current().cancelRequested;
   } catch (e) {
-    if (!(e instanceof CancelledError)) {
+    if (!(e instanceof CancelledFailure)) {
       throw e;
     }
     if (when === 'after-cleanup') {

--- a/packages/workflow/src/errors.ts
+++ b/packages/workflow/src/errors.ts
@@ -1,22 +1,10 @@
+import { CancelledFailure, ActivityFailure, ChildWorkflowFailure } from '@temporalio/common';
+
 /**
  * Base class for all workflow errors
  */
 export class WorkflowError extends Error {
   public readonly name: string = 'WorkflowError';
-}
-
-/**
- * Thrown in workflow when it is requested to be cancelled either externally or internally
- */
-export class CancelledError extends WorkflowError {
-  public readonly name: string = 'CancelledError';
-}
-
-/**
- * Thrown in workflow when it receives a client cancellation request
- */
-export class WorkflowCancelledError extends CancelledError {
-  public readonly name: string = 'WorkflowCancelledError';
 }
 
 /**
@@ -42,4 +30,14 @@ export class WorkflowExecutionAlreadyStartedError extends WorkflowError {
   constructor(message: string, public readonly workflowId: string, public readonly workflowType: string) {
     super(message);
   }
+}
+
+/**
+ * Returns whether provided `err` is caused by cancellation
+ */
+export function isCancellation(err: unknown): boolean {
+  return (
+    err instanceof CancelledFailure ||
+    ((err instanceof ActivityFailure || err instanceof ChildWorkflowFailure) && err.cause instanceof CancelledFailure)
+  );
 }

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -62,6 +62,14 @@ export {
   defaultDataConverter,
   DataConverter,
   WorkflowIdReusePolicy,
+  ActivityFailure,
+  ApplicationFailure,
+  CancelledFailure,
+  ChildWorkflowFailure,
+  ServerFailure,
+  TemporalFailure,
+  TerminatedFailure,
+  TimeoutFailure,
 } from '@temporalio/common';
 export {
   ApplyMode,

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -386,7 +386,7 @@ export class ContextImpl {
   /**
    * Returns whether or not this workflow received a cancellation request.
    *
-   * The workflow might still be running in case {@link CancelledError}s were caught.
+   * The workflow might still be running in case cancellation was handled.
    */
   public get cancelled(): boolean {
     return state.cancelled;


### PR DESCRIPTION
BREAKING CHANGE: use `isCancellation(err)` instead of catching `CancelledError` for
handling cancellations, cancelled activities and child workflows now throw
`ActivityFailure` and `ChildWorkflowFailure` respectively with cause set
to `CancelledFailure`.

Closes #178 