### PR TITLE
fix(worker): Avoid throwing error when there's no activities directory

### DIFF
--- a/packages/worker/src/isolate-builder.ts
+++ b/packages/worker/src/isolate-builder.ts
@@ -98,6 +98,11 @@ export class WorkflowIsolateBuilder {
 
       module.exports = api;
     `;
+    try {
+      vol.mkdirSync(path.dirname(target), { recursive: true });
+    } catch (err) {
+      if (err.code !== 'EEXIST') throw err;
+    }
     vol.writeFileSync(target, code);
   }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Added a missing `mkdir()` call

## Why?
<!-- Tell your future self why have you made these changes -->

If there's no activities, `registerActivities()` doesn't call `mkdir()`, so the `writeFileSync()` call will fail

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
