### PR TITLE
fix(worker): Avoid throwing error when there are no activities

### DIFF
--- a/packages/worker/src/isolate-builder.ts
+++ b/packages/worker/src/isolate-builder.ts
@@ -100,10 +100,10 @@ export class WorkflowIsolateBuilder {
     `;
     try {
       vol.mkdirSync(path.dirname(target), { recursive: true });
+      vol.writeFileSync(target, code);
     } catch (err) {
       if (err.code !== 'EEXIST') throw err;
     }
-    vol.writeFileSync(target, code);
   }
 
   /**


### PR DESCRIPTION
## What was changed

Avoid throwing error when there are no activities.

## Why?

I'm still seeing a residual error in samples-node/progress:

Error: ENOENT: no such file or directory, open '/src/main.js'

From https://github.com/temporalio/sdk-node/blob/main/packages/worker/src/isolate-builder.ts#L45

genEntryPoint

## Checklist

2. How was this tested: