### PR TITLE
OTel collector in node

### DIFF
--- a/etc/prometheus.yml
+++ b/etc/prometheus.yml
@@ -1,0 +1,31 @@
+global:
+  scrape_interval: 15s
+  scrape_timeout: 10s
+  evaluation_interval: 15s
+alerting:
+  alertmanagers:
+    - follow_redirects: true
+      scheme: http
+      timeout: 10s
+      api_version: v2
+      static_configs:
+        - targets: []
+scrape_configs:
+  - job_name: prometheus
+    honor_timestamps: true
+    scrape_interval: 15s
+    scrape_timeout: 10s
+    metrics_path: /metrics
+    scheme: http
+    static_configs:
+      - targets:
+          - localhost:9090
+  - job_name: temporal-sdk
+    honor_timestamps: true
+    scrape_interval: 2s
+    scrape_timeout: 1s
+    metrics_path: /metrics
+    scheme: http
+    static_configs:
+      - targets:
+          - host.docker.internal:9464

--- a/package-lock.json
+++ b/package-lock.json
@@ -2020,15 +2020,14 @@
         "@opentelemetry/api": "^1.0.1"
       }
     },
-    "node_modules/@opentelemetry/exporter-zipkin": {
+    "node_modules/@opentelemetry/exporter-prometheus": {
       "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-0.24.0.tgz",
-      "integrity": "sha512-SUV9yKnl7QrXL7EP2/xY3ryP1giSkQHTE+9uoLt/yC8hLCvh5AnJmBk5g9COaBQ6qANFEVKs74LJcjTOZU2dgg==",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.24.0.tgz",
+      "integrity": "sha512-sPFn+7DSbqQBQ+BrWitL356RnJmMkokSCnvqk5r8vRj4PRBwbbnHZnRgDdsczgj0tFIHzSK87X+H4eGXpYW1WA==",
       "dependencies": {
+        "@opentelemetry/api-metrics": "0.24.0",
         "@opentelemetry/core": "0.24.0",
-        "@opentelemetry/resources": "0.24.0",
-        "@opentelemetry/semantic-conventions": "0.24.0",
-        "@opentelemetry/tracing": "0.24.0"
+        "@opentelemetry/metrics": "0.24.0"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -12127,6 +12126,7 @@
       "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
+        "@opentelemetry/exporter-prometheus": "^0.24.0",
         "@temporalio/client": "file:../client",
         "@temporalio/common": "file:../common",
         "@temporalio/proto": "file:../proto",
@@ -12152,6 +12152,7 @@
       "dependencies": {
         "@opentelemetry/api": "^1.0.2",
         "@opentelemetry/core": "^0.24.0",
+        "@opentelemetry/metrics": "^0.24.0",
         "@opentelemetry/resources": "^0.24.0",
         "@opentelemetry/tracing": "^0.24.0",
         "@temporalio/activity": "file:../activity",
@@ -13830,14 +13831,14 @@
         "jaeger-client": "^3.15.0"
       }
     },
-    "@opentelemetry/exporter-zipkin": {
-      "version": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-0.24.0.tgz",
-      "integrity": "sha512-SUV9yKnl7QrXL7EP2/xY3ryP1giSkQHTE+9uoLt/yC8hLCvh5AnJmBk5g9COaBQ6qANFEVKs74LJcjTOZU2dgg==",
+    "@opentelemetry/exporter-prometheus": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.24.0.tgz",
+      "integrity": "sha512-sPFn+7DSbqQBQ+BrWitL356RnJmMkokSCnvqk5r8vRj4PRBwbbnHZnRgDdsczgj0tFIHzSK87X+H4eGXpYW1WA==",
       "requires": {
+        "@opentelemetry/api-metrics": "0.24.0",
         "@opentelemetry/core": "0.24.0",
-        "@opentelemetry/resources": "0.24.0",
-        "@opentelemetry/semantic-conventions": "0.24.0",
-        "@opentelemetry/tracing": "0.24.0"
+        "@opentelemetry/metrics": "0.24.0"
       }
     },
     "@opentelemetry/instrumentation": {
@@ -14094,6 +14095,7 @@
     "@temporalio/test": {
       "version": "file:packages/test",
       "requires": {
+        "@opentelemetry/exporter-prometheus": "^0.24.0",
         "@temporalio/client": "file:../client",
         "@temporalio/common": "file:../common",
         "@temporalio/proto": "file:../proto",
@@ -14115,6 +14117,7 @@
       "requires": {
         "@opentelemetry/api": "^1.0.2",
         "@opentelemetry/core": "^0.24.0",
+        "@opentelemetry/metrics": "^0.24.0",
         "@opentelemetry/resources": "^0.24.0",
         "@opentelemetry/tracing": "^0.24.0",
         "@temporalio/activity": "file:../activity",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1856,9 +1856,9 @@
       }
     },
     "node_modules/@octokit/graphql": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.7.0.tgz",
-      "integrity": "sha512-diY0qMPyQjfu4rDu3kDhJ9qIZadIm4IISO3RJSv9ajYUWJUCO0AykbgzLcg1xclxtXgzY583u3gAv66M6zz5SA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
+      "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
       "dev": true,
       "dependencies": {
         "@octokit/request": "^5.6.0",
@@ -1867,9 +1867,9 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-9.7.0.tgz",
-      "integrity": "sha512-TUJ16DJU8mekne6+KVcMV5g6g/rJlrnIKn7aALG9QrNpnEipFc1xjoarh0PKaAWf2Hf+HwthRKYt+9mCm5RsRg==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-10.0.0.tgz",
+      "integrity": "sha512-k1iO2zKuEjjRS1EJb4FwSLk+iF6EGp+ZV0OMRViQoWhQ1fZTk9hg1xccZII5uyYoiqcbC73MRBmT45y1vp2PPg==",
       "dev": true
     },
     "node_modules/@octokit/plugin-enterprise-rest": {
@@ -1879,12 +1879,12 @@
       "dev": true
     },
     "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.15.1.tgz",
-      "integrity": "sha512-47r52KkhQDkmvUKZqXzA1lKvcyJEfYh3TKAIe5+EzMeyDM3d+/s5v11i2gTk8/n6No6DPi3k5Ind6wtDbo/AEg==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.16.0.tgz",
+      "integrity": "sha512-8YYzALPMvEZ35kgy5pdYvQ22Roz+BIuEaedO575GwE2vb/ACDqQn0xQrTJR4tnZCJn7pi8+AWPVjrFDaERIyXQ==",
       "dev": true,
       "dependencies": {
-        "@octokit/types": "^6.24.0"
+        "@octokit/types": "^6.26.0"
       },
       "peerDependencies": {
         "@octokit/core": ">=2"
@@ -1900,12 +1900,12 @@
       }
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.8.0.tgz",
-      "integrity": "sha512-qeLZZLotNkoq+it6F+xahydkkbnvSK0iDjlXFo3jNTB+Ss0qIbYQb9V/soKLMkgGw8Q2sHjY5YEXiA47IVPp4A==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.9.0.tgz",
+      "integrity": "sha512-Rz67pg+rEJq2Qn/qfHsMiBoP7GL5NDn8Gg0ezGznZ745Ixn1gPusZYZqCXNhICYrIZaVXmusNP0iwPdphJneqQ==",
       "dev": true,
       "dependencies": {
-        "@octokit/types": "^6.25.0",
+        "@octokit/types": "^6.26.0",
         "deprecation": "^2.3.1"
       },
       "peerDependencies": {
@@ -1938,24 +1938,24 @@
       }
     },
     "node_modules/@octokit/rest": {
-      "version": "18.9.1",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.9.1.tgz",
-      "integrity": "sha512-idZ3e5PqXVWOhtZYUa546IDHTHjkGZbj3tcJsN0uhCy984KD865e8GB2WbYDc2ZxFuJRiyd0AftpL2uPNhF+UA==",
+      "version": "18.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.10.0.tgz",
+      "integrity": "sha512-esHR5OKy38bccL/sajHqZudZCvmv4yjovMJzyXlphaUo7xykmtOdILGJ3aAm0mFHmMLmPFmDMJXf39cAjNJsrw==",
       "dev": true,
       "dependencies": {
-        "@octokit/core": "^3.5.0",
-        "@octokit/plugin-paginate-rest": "^2.6.2",
-        "@octokit/plugin-request-log": "^1.0.2",
-        "@octokit/plugin-rest-endpoint-methods": "5.8.0"
+        "@octokit/core": "^3.5.1",
+        "@octokit/plugin-paginate-rest": "^2.16.0",
+        "@octokit/plugin-request-log": "^1.0.4",
+        "@octokit/plugin-rest-endpoint-methods": "^5.9.0"
       }
     },
     "node_modules/@octokit/types": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.25.0.tgz",
-      "integrity": "sha512-bNvyQKfngvAd/08COlYIN54nRgxskmejgywodizQNyiKoXmWRAjKup2/LYwm+T9V0gsKH6tuld1gM0PzmOiB4Q==",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.26.0.tgz",
+      "integrity": "sha512-RDxZBAFMtqs1ZPnbUu1e7ohPNfoNhTiep4fErY7tZs995BeHu369Vsh5woMIaFbllRWEZBfvTCS4hvDnMPiHrA==",
       "dev": true,
       "dependencies": {
-        "@octokit/openapi-types": "^9.5.0"
+        "@octokit/openapi-types": "^10.0.0"
       }
     },
     "node_modules/@opentelemetry/api": {
@@ -2012,6 +2012,23 @@
         "@opentelemetry/semantic-conventions": "0.24.0",
         "@opentelemetry/tracing": "0.24.0",
         "jaeger-client": "^3.15.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.1"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-zipkin": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-0.24.0.tgz",
+      "integrity": "sha512-SUV9yKnl7QrXL7EP2/xY3ryP1giSkQHTE+9uoLt/yC8hLCvh5AnJmBk5g9COaBQ6qANFEVKs74LJcjTOZU2dgg==",
+      "dependencies": {
+        "@opentelemetry/core": "0.24.0",
+        "@opentelemetry/resources": "0.24.0",
+        "@opentelemetry/semantic-conventions": "0.24.0",
+        "@opentelemetry/tracing": "0.24.0"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -2390,9 +2407,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.7.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.9.tgz",
-      "integrity": "sha512-KktxVzS4FPDFVHUUOWyZMvRo//8vqOLITtLMhFSW9IdLsYT/sPyXj3wXtaTcR7A7olCe7R2Xy7R+q5pg2bU46g=="
+      "version": "16.7.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.10.tgz",
+      "integrity": "sha512-S63Dlv4zIPb8x6MMTgDq5WWRJQe56iBEY0O3SOFA9JrRienkOVDXSXBjjJw6HTNQYSE2JI6GMCR6LVbIMHJVvA=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.5.12",
@@ -2993,37 +3010,16 @@
       "dev": true
     },
     "node_modules/are-we-there-yet": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.6.tgz",
+      "integrity": "sha512-+1byPnimWdGcKFRS48zG73nxM08kamPFReUYvEmRXI3E8E4YhF4voMRDaGlfGD1UeRHEgs4NhQCE28KI8JVj1A==",
       "dev": true,
       "dependencies": {
         "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
-      }
-    },
-    "node_modules/are-we-there-yet/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dev": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/are-we-there-yet/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/arg": {
@@ -4667,9 +4663,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.824",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.824.tgz",
-      "integrity": "sha512-Fk+5aD0HDi9i9ZKt9n2VPOZO1dQy7PV++hz2wJ/KIn+CvVfu4fny39squHtyVDPuHNuoJGAZIbuReEklqYIqfA=="
+      "version": "1.3.827",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.827.tgz",
+      "integrity": "sha512-ye+4uQOY/jbjRutMcE/EmOcNwUeo1qo9aKL2tPyb09cU3lmxNeyDF4RWiemmkknW+p29h7dyDqy02higTxc9/A=="
     },
     "node_modules/emittery": {
       "version": "0.8.1",
@@ -6519,9 +6515,9 @@
       }
     },
     "node_modules/init-package-json/node_modules/read-package-json": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-4.0.1.tgz",
-      "integrity": "sha512-czqCcYfkEl6sIFJVOND/5/Goseu7cVw1rcDUATq6ED0jLGjMm9/HOPmFmEZMvRu9yl272YERaMUcOlvcNU9InQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-4.1.1.tgz",
+      "integrity": "sha512-P82sbZJ3ldDrWCOSKxJT0r/CXMWR0OR3KRh55SgKo3p91GSIEEC32v3lSHAvO/UcH3/IoL7uqhOFBduAnwdldw==",
       "dev": true,
       "dependencies": {
         "glob": "^7.1.1",
@@ -7690,9 +7686,9 @@
       }
     },
     "node_modules/memfs": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.2.2.tgz",
-      "integrity": "sha512-RE0CwmIM3CEvpcdK3rZ19BC4E6hv9kADkMN5rPduRak58cNArWLi/9jFLsa4rhsjfVxMP3v0jO7FHXq7SvFY5Q==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.2.3.tgz",
+      "integrity": "sha512-vDKa1icg0KDNzcOPBPAduFFb3YL+pLbQ/3hW7rRgUKpoliTAkPmVV7r/3qJ6YqKyIXEDhzsdSvLlEh137AfWUA==",
       "dependencies": {
         "fs-monkey": "1.0.3"
       },
@@ -11012,16 +11008,16 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.1.4.tgz",
-      "integrity": "sha512-C2WkFwstHDhVEmsmlCxrXUtVklS+Ir1A7twrYzrDrQQOIMOaVAYykaoo/Aq1K0QRkMoY2hhvDQY1cm4jnIMFwA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.2.0.tgz",
+      "integrity": "sha512-FpR4Qe0Yt4knSQ5u2bA1wkM0R8VlVsvhyfSHvomXRivS4vPLk0dJV2IhRBIHRABh7AFutdMeElIA5y1dETwMBg==",
       "dependencies": {
-        "jest-worker": "^27.0.2",
+        "jest-worker": "^27.0.6",
         "p-limit": "^3.1.0",
-        "schema-utils": "^3.0.0",
+        "schema-utils": "^3.1.1",
         "serialize-javascript": "^6.0.0",
         "source-map": "^0.6.1",
-        "terser": "^5.7.0"
+        "terser": "^5.7.2"
       },
       "engines": {
         "node": ">= 10.13.0"
@@ -11032,6 +11028,17 @@
       },
       "peerDependencies": {
         "webpack": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "uglify-js": {
+          "optional": true
+        }
       }
     },
     "node_modules/terser/node_modules/source-map": {
@@ -12011,6 +12018,7 @@
       }
     },
     "packages/activity": {
+      "name": "@temporalio/activity",
       "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
@@ -12018,6 +12026,7 @@
       }
     },
     "packages/client": {
+      "name": "@temporalio/client",
       "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
@@ -12038,6 +12047,7 @@
       }
     },
     "packages/common": {
+      "name": "@temporalio/common",
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
@@ -12046,15 +12056,18 @@
       }
     },
     "packages/core-bridge": {
+      "name": "@temporalio/core-bridge",
       "version": "0.3.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@temporalio/common": "file:../common",
-        "cargo-cp-artifact": "^0.1.4"
+        "cargo-cp-artifact": "^0.1.4",
+        "long": "^4.0.0"
       }
     },
     "packages/create-project": {
+      "name": "@temporalio/create",
       "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
@@ -12066,11 +12079,13 @@
       }
     },
     "packages/interceptors-opentelemetry": {
+      "name": "@temporalio/interceptors-opentelemetry",
       "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.0.2",
         "@opentelemetry/exporter-jaeger": "^0.24.0",
+        "@opentelemetry/resources": "^0.24.0",
         "@opentelemetry/sdk-node": "^0.24.0",
         "@temporalio/client": "file:../client",
         "@temporalio/common": "file:../common",
@@ -12079,6 +12094,7 @@
       }
     },
     "packages/meta": {
+      "name": "temporalio",
       "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
@@ -12093,6 +12109,7 @@
       }
     },
     "packages/proto": {
+      "name": "@temporalio/proto",
       "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
@@ -12106,6 +12123,7 @@
       }
     },
     "packages/test": {
+      "name": "@temporalio/test",
       "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
@@ -12127,11 +12145,15 @@
       }
     },
     "packages/worker": {
+      "name": "@temporalio/worker",
       "version": "0.8.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.0.2",
+        "@opentelemetry/core": "^0.24.0",
+        "@opentelemetry/resources": "^0.24.0",
+        "@opentelemetry/tracing": "^0.24.0",
         "@temporalio/activity": "file:../activity",
         "@temporalio/common": "file:../common",
         "@temporalio/core-bridge": "file:../core-bridge",
@@ -12175,6 +12197,7 @@
       }
     },
     "packages/workflow": {
+      "name": "@temporalio/workflow",
       "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
@@ -13676,9 +13699,9 @@
       }
     },
     "@octokit/graphql": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.7.0.tgz",
-      "integrity": "sha512-diY0qMPyQjfu4rDu3kDhJ9qIZadIm4IISO3RJSv9ajYUWJUCO0AykbgzLcg1xclxtXgzY583u3gAv66M6zz5SA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
+      "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
       "dev": true,
       "requires": {
         "@octokit/request": "^5.6.0",
@@ -13687,9 +13710,9 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-9.7.0.tgz",
-      "integrity": "sha512-TUJ16DJU8mekne6+KVcMV5g6g/rJlrnIKn7aALG9QrNpnEipFc1xjoarh0PKaAWf2Hf+HwthRKYt+9mCm5RsRg==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-10.0.0.tgz",
+      "integrity": "sha512-k1iO2zKuEjjRS1EJb4FwSLk+iF6EGp+ZV0OMRViQoWhQ1fZTk9hg1xccZII5uyYoiqcbC73MRBmT45y1vp2PPg==",
       "dev": true
     },
     "@octokit/plugin-enterprise-rest": {
@@ -13699,12 +13722,12 @@
       "dev": true
     },
     "@octokit/plugin-paginate-rest": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.15.1.tgz",
-      "integrity": "sha512-47r52KkhQDkmvUKZqXzA1lKvcyJEfYh3TKAIe5+EzMeyDM3d+/s5v11i2gTk8/n6No6DPi3k5Ind6wtDbo/AEg==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.16.0.tgz",
+      "integrity": "sha512-8YYzALPMvEZ35kgy5pdYvQ22Roz+BIuEaedO575GwE2vb/ACDqQn0xQrTJR4tnZCJn7pi8+AWPVjrFDaERIyXQ==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^6.24.0"
+        "@octokit/types": "^6.26.0"
       }
     },
     "@octokit/plugin-request-log": {
@@ -13715,12 +13738,12 @@
       "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.8.0.tgz",
-      "integrity": "sha512-qeLZZLotNkoq+it6F+xahydkkbnvSK0iDjlXFo3jNTB+Ss0qIbYQb9V/soKLMkgGw8Q2sHjY5YEXiA47IVPp4A==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.9.0.tgz",
+      "integrity": "sha512-Rz67pg+rEJq2Qn/qfHsMiBoP7GL5NDn8Gg0ezGznZ745Ixn1gPusZYZqCXNhICYrIZaVXmusNP0iwPdphJneqQ==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^6.25.0",
+        "@octokit/types": "^6.26.0",
         "deprecation": "^2.3.1"
       }
     },
@@ -13750,24 +13773,24 @@
       }
     },
     "@octokit/rest": {
-      "version": "18.9.1",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.9.1.tgz",
-      "integrity": "sha512-idZ3e5PqXVWOhtZYUa546IDHTHjkGZbj3tcJsN0uhCy984KD865e8GB2WbYDc2ZxFuJRiyd0AftpL2uPNhF+UA==",
+      "version": "18.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.10.0.tgz",
+      "integrity": "sha512-esHR5OKy38bccL/sajHqZudZCvmv4yjovMJzyXlphaUo7xykmtOdILGJ3aAm0mFHmMLmPFmDMJXf39cAjNJsrw==",
       "dev": true,
       "requires": {
-        "@octokit/core": "^3.5.0",
-        "@octokit/plugin-paginate-rest": "^2.6.2",
-        "@octokit/plugin-request-log": "^1.0.2",
-        "@octokit/plugin-rest-endpoint-methods": "5.8.0"
+        "@octokit/core": "^3.5.1",
+        "@octokit/plugin-paginate-rest": "^2.16.0",
+        "@octokit/plugin-request-log": "^1.0.4",
+        "@octokit/plugin-rest-endpoint-methods": "^5.9.0"
       }
     },
     "@octokit/types": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.25.0.tgz",
-      "integrity": "sha512-bNvyQKfngvAd/08COlYIN54nRgxskmejgywodizQNyiKoXmWRAjKup2/LYwm+T9V0gsKH6tuld1gM0PzmOiB4Q==",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.26.0.tgz",
+      "integrity": "sha512-RDxZBAFMtqs1ZPnbUu1e7ohPNfoNhTiep4fErY7tZs995BeHu369Vsh5woMIaFbllRWEZBfvTCS4hvDnMPiHrA==",
       "dev": true,
       "requires": {
-        "@octokit/openapi-types": "^9.5.0"
+        "@octokit/openapi-types": "^10.0.0"
       }
     },
     "@opentelemetry/api": {
@@ -13805,6 +13828,16 @@
         "@opentelemetry/semantic-conventions": "0.24.0",
         "@opentelemetry/tracing": "0.24.0",
         "jaeger-client": "^3.15.0"
+      }
+    },
+    "@opentelemetry/exporter-zipkin": {
+      "version": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-0.24.0.tgz",
+      "integrity": "sha512-SUV9yKnl7QrXL7EP2/xY3ryP1giSkQHTE+9uoLt/yC8hLCvh5AnJmBk5g9COaBQ6qANFEVKs74LJcjTOZU2dgg==",
+      "requires": {
+        "@opentelemetry/core": "0.24.0",
+        "@opentelemetry/resources": "0.24.0",
+        "@opentelemetry/semantic-conventions": "0.24.0",
+        "@opentelemetry/tracing": "0.24.0"
       }
     },
     "@opentelemetry/instrumentation": {
@@ -14024,7 +14057,8 @@
       "version": "file:packages/core-bridge",
       "requires": {
         "@temporalio/common": "file:../common",
-        "cargo-cp-artifact": "^0.1.4"
+        "cargo-cp-artifact": "^0.1.4",
+        "long": "^4.0.0"
       }
     },
     "@temporalio/create": {
@@ -14039,6 +14073,7 @@
       "requires": {
         "@opentelemetry/api": "^1.0.2",
         "@opentelemetry/exporter-jaeger": "^0.24.0",
+        "@opentelemetry/resources": "^0.24.0",
         "@opentelemetry/sdk-node": "^0.24.0",
         "@temporalio/client": "file:../client",
         "@temporalio/common": "file:../common",
@@ -14079,6 +14114,9 @@
       "version": "file:packages/worker",
       "requires": {
         "@opentelemetry/api": "^1.0.2",
+        "@opentelemetry/core": "^0.24.0",
+        "@opentelemetry/resources": "^0.24.0",
+        "@opentelemetry/tracing": "^0.24.0",
         "@temporalio/activity": "file:../activity",
         "@temporalio/common": "file:../common",
         "@temporalio/core-bridge": "file:../core-bridge",
@@ -14206,9 +14244,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.7.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.9.tgz",
-      "integrity": "sha512-KktxVzS4FPDFVHUUOWyZMvRo//8vqOLITtLMhFSW9IdLsYT/sPyXj3wXtaTcR7A7olCe7R2Xy7R+q5pg2bU46g=="
+      "version": "16.7.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.10.tgz",
+      "integrity": "sha512-S63Dlv4zIPb8x6MMTgDq5WWRJQe56iBEY0O3SOFA9JrRienkOVDXSXBjjJw6HTNQYSE2JI6GMCR6LVbIMHJVvA=="
     },
     "@types/node-fetch": {
       "version": "2.5.12",
@@ -14666,39 +14704,13 @@
       "dev": true
     },
     "are-we-there-yet": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.6.tgz",
+      "integrity": "sha512-+1byPnimWdGcKFRS48zG73nxM08kamPFReUYvEmRXI3E8E4YhF4voMRDaGlfGD1UeRHEgs4NhQCE28KI8JVj1A==",
       "dev": true,
       "requires": {
         "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
+        "readable-stream": "^3.6.0"
       }
     },
     "arg": {
@@ -15988,9 +16000,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.824",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.824.tgz",
-      "integrity": "sha512-Fk+5aD0HDi9i9ZKt9n2VPOZO1dQy7PV++hz2wJ/KIn+CvVfu4fny39squHtyVDPuHNuoJGAZIbuReEklqYIqfA=="
+      "version": "1.3.827",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.827.tgz",
+      "integrity": "sha512-ye+4uQOY/jbjRutMcE/EmOcNwUeo1qo9aKL2tPyb09cU3lmxNeyDF4RWiemmkknW+p29h7dyDqy02higTxc9/A=="
     },
     "emittery": {
       "version": "0.8.1",
@@ -17380,9 +17392,9 @@
       },
       "dependencies": {
         "read-package-json": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-4.0.1.tgz",
-          "integrity": "sha512-czqCcYfkEl6sIFJVOND/5/Goseu7cVw1rcDUATq6ED0jLGjMm9/HOPmFmEZMvRu9yl272YERaMUcOlvcNU9InQ==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-4.1.1.tgz",
+          "integrity": "sha512-P82sbZJ3ldDrWCOSKxJT0r/CXMWR0OR3KRh55SgKo3p91GSIEEC32v3lSHAvO/UcH3/IoL7uqhOFBduAnwdldw==",
           "dev": true,
           "requires": {
             "glob": "^7.1.1",
@@ -18283,9 +18295,9 @@
       }
     },
     "memfs": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.2.2.tgz",
-      "integrity": "sha512-RE0CwmIM3CEvpcdK3rZ19BC4E6hv9kADkMN5rPduRak58cNArWLi/9jFLsa4rhsjfVxMP3v0jO7FHXq7SvFY5Q==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.2.3.tgz",
+      "integrity": "sha512-vDKa1icg0KDNzcOPBPAduFFb3YL+pLbQ/3hW7rRgUKpoliTAkPmVV7r/3qJ6YqKyIXEDhzsdSvLlEh137AfWUA==",
       "requires": {
         "fs-monkey": "1.0.3"
       }
@@ -20806,16 +20818,16 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.1.4.tgz",
-      "integrity": "sha512-C2WkFwstHDhVEmsmlCxrXUtVklS+Ir1A7twrYzrDrQQOIMOaVAYykaoo/Aq1K0QRkMoY2hhvDQY1cm4jnIMFwA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.2.0.tgz",
+      "integrity": "sha512-FpR4Qe0Yt4knSQ5u2bA1wkM0R8VlVsvhyfSHvomXRivS4vPLk0dJV2IhRBIHRABh7AFutdMeElIA5y1dETwMBg==",
       "requires": {
-        "jest-worker": "^27.0.2",
+        "jest-worker": "^27.0.6",
         "p-limit": "^3.1.0",
-        "schema-utils": "^3.0.0",
+        "schema-utils": "^3.1.1",
         "serialize-javascript": "^6.0.0",
         "source-map": "^0.6.1",
-        "terser": "^5.7.0"
+        "terser": "^5.7.2"
       }
     },
     "text-extensions": {

--- a/packages/core-bridge/Cargo.lock
+++ b/packages/core-bridge/Cargo.lock
@@ -30,9 +30,9 @@ checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
 
 [[package]]
 name = "arc-swap"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34a23efe54373080cf871532e2d01076be41c4c896d32ef63af1b2dded924b03"
+checksum = "b5ab7d9e73059c86c36473f459b52adbd99c3554a4fec492caef460806006f00"
 
 [[package]]
 name = "async-stream"
@@ -102,12 +102,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
 
 [[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
-
-[[package]]
 name = "bytes"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,9 +109,9 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cc"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
+checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
 
 [[package]]
 name = "cfg-if"
@@ -352,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adc00f486adfc9ce99f77d717836f0c5aa84965eb0b4f051f4e83f7cab53f8b"
+checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -367,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74ed2411805f6e4e3d9bc904c95d5d423b89b3b25dc0250aa74729de20629ff9"
+checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -377,15 +371,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99"
+checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d0d535a57b87e1ae31437b892713aee90cd2d7b0ee48727cd11fc72ef54761c"
+checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -394,15 +388,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b0e06c393068f3a6ef246c75cdca793d6a46347e75286933e5e75fd2fd11582"
+checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54913bae956fb8df7f4dc6fc90362aa72e69148e3f39041fbe8742d21e0ac57"
+checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
 dependencies = [
  "autocfg",
  "proc-macro-hack",
@@ -424,21 +418,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f30aaa67363d119812743aa5f33c201a7a66329f97d1a887022971feea4b53"
+checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
 
 [[package]]
 name = "futures-task"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe54a98670017f3be909561f6ad13e810d9a51f3f061b902062ca3da80799f2"
+checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
 
 [[package]]
 name = "futures-util"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eb846bfd58e44a8481a00049e82c43e0ccb5d61f8dc071057cb19249dd4d78"
+checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
 dependencies = [
  "autocfg",
  "futures-channel",
@@ -619,12 +613,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "integer-encoding"
-version = "1.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48dc51180a9b377fd75814d0cc02199c20f8e99433d6762f650d39cdbbd3b56f"
-
-[[package]]
 name = "itertools"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,9 +660,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
+checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
 dependencies = [
  "scopeguard",
 ]
@@ -806,69 +794,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d047c1062aa51e256408c560894e5251f08925980e53cf1aa5bd00eec6512"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
-dependencies = [
- "autocfg",
- "num-bigint",
- "num-integer",
  "num-traits",
 ]
 
@@ -905,50 +836,31 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "opentelemetry"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff27b33e30432e7b9854936693ca103d8591b0501f7ae9f633de48cda3bf2a67"
+checksum = "e1cf9b1c4e9a6c4de793c632496fa490bdc0e1eea73f0c91394f7b6990935d22"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
+ "dashmap",
+ "fnv",
  "futures",
  "js-sys",
  "lazy_static",
  "percent-encoding",
  "pin-project",
  "rand",
+ "serde",
  "thiserror",
  "tokio",
  "tokio-stream",
 ]
 
 [[package]]
-name = "opentelemetry-jaeger"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a9fc8192722e7daa0c56e59e2336b797122fb8598383dcb11c8852733b435c"
-dependencies = [
- "async-trait",
- "lazy_static",
- "opentelemetry",
- "thiserror",
- "thrift",
-]
-
-[[package]]
-name = "ordered-float"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "parking_lot"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
@@ -957,9 +869,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
  "cfg-if",
  "instant",
@@ -1046,9 +958,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
+checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
 dependencies = [
  "unicode-xid",
 ]
@@ -1301,23 +1213,22 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.4.0"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9bd29cdffb8875b04f71c51058f940cf4e390bbfd2ce669c4f22cd70b492a5"
+checksum = "525bc1abfda2e1998d152c45cf13e696f76d0a4972310b22fac1658b05df7c87"
 dependencies = [
  "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
- "num",
  "security-framework-sys",
 ]
 
 [[package]]
 name = "security-framework-sys"
-version = "2.4.0"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19133a286e494cc3311c165c4676ccb1fd47bed45b55f9d71fbd784ad4cea6f8"
+checksum = "a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1358,15 +1269,29 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.129"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1f72836d2aa753853178eda473a3b9d8e4eefdaf20523b919677e6de489f8f1"
+checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.130"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "serde_json"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
+checksum = "a7f9e390c27c3c0ce8bc5d725f6e4d30a29d26659494aa4b17535f7522c5c950"
 dependencies = [
  "itoa",
  "ryu",
@@ -1390,9 +1315,9 @@ checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
 
 [[package]]
 name = "slotmap"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a952280edbecfb1d4bd3cf2dbc309dc6ab523e53487c438ae21a6df09fe84bc4"
+checksum = "e1e08e261d0e8f5c43123b7adf3e4ca1690d655377ac93a03b2c9d3e98de1342"
 dependencies = [
  "version_check",
 ]
@@ -1470,13 +1395,13 @@ dependencies = [
  "lru",
  "once_cell",
  "opentelemetry",
- "opentelemetry-jaeger",
  "parking_lot",
  "prost",
  "prost-types",
  "rand",
  "rustfsm",
  "slotmap",
+ "temporal-sdk-core-protos",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -1491,32 +1416,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "temporal-sdk-core-protos"
+version = "0.1.0"
+dependencies = [
+ "derive_more",
+ "prost",
+ "prost-types",
+ "tonic",
+ "tonic-build",
+]
+
+[[package]]
 name = "temporal-sdk-node-bridge"
 version = "0.1.0"
 dependencies = [
  "futures",
  "neon",
  "once_cell",
+ "opentelemetry",
  "prost",
  "prost-types",
+ "serde",
+ "serde_json",
  "temporal-sdk-core",
+ "temporal-sdk-core-protos",
  "tokio",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.26"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
+checksum = "283d5230e63df9608ac7d9691adc1dfb6e701225436eb64d0b9a7f0a5a04f6ec"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.26"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
+checksum = "fa3884228611f5cd3608e2d409bf7dce832e4eb3135e3f11addbd7e41bd68e71"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1530,28 +1470,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "threadpool"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
-dependencies = [
- "num_cpus",
-]
-
-[[package]]
-name = "thrift"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6d965454947cc7266d22716ebfd07b18d84ebaf35eec558586bbb2a8cb6b5b"
-dependencies = [
- "byteorder",
- "integer-encoding",
- "log",
- "ordered-float",
- "threadpool",
 ]
 
 [[package]]
@@ -1777,9 +1695,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c47440f2979c4cd3138922840eec122e3c0ba2148bc290f756bd7fd60fc97fff"
+checksum = "599f388ecb26b28d9c1b2e4437ae019a7b336018b45ed911458cd9ebf91129f6"
 dependencies = [
  "opentelemetry",
  "tracing",
@@ -1808,6 +1726,7 @@ dependencies = [
  "chrono",
  "lazy_static",
  "matchers",
+ "parking_lot",
  "regex",
  "serde",
  "serde_json",

--- a/packages/core-bridge/Cargo.toml
+++ b/packages/core-bridge/Cargo.toml
@@ -13,9 +13,14 @@ crate-type = ["cdylib"]
 [dependencies]
 futures = { version = "0.3", features = ["executor"] }
 neon = { version = "0.8.0", default-features = false, features = ["napi-4", "event-queue-api"] }
+once_cell = "1.7.2"
+opentelemetry = { version = "0.16", features = ["rt-tokio-current-thread", "serialize"] }
 prost = "0.8"
 prost-types = "0.8"
+serde = "1.0"
+serde_json = "1.0"
 tokio = "1.4.0"
-once_cell = "1.7.2"
 # TODO: revert back to version *, can't now because of this error: prerelease package needs to be specified explicitly
-temporal-sdk-core = { version = "0.1.0-alpha.1", path = "./sdk-core" }
+#temporal-sdk-core = { version = "0.1.0-alpha.1", path = "./sdk-core" }
+temporal-sdk-core = { version = "0.1.0-alpha.1", path = "../../../sdk-core" }
+temporal-sdk-core-protos = { version = "*", path = "../../../sdk-core/sdk-core-protos" }

--- a/packages/core-bridge/index.d.ts
+++ b/packages/core-bridge/index.d.ts
@@ -65,6 +65,19 @@ export interface CoreOptions {
    * Options for communicating with the Temporal server
    */
   serverOptions: ServerOptions;
+
+  /**
+   * Telemetry options
+   */
+  telemetryOptions: TelemetryOptions;
+}
+
+/**
+ * Configure telemetry
+ */
+export interface TelemetryOptions {
+  /** Will be called every time a new batch of spans is exported from core */
+  spanBatchCallback: (err: Error, serializedSpanBatch: ArrayBuffer) => void;
 }
 
 export interface WorkerOptions {

--- a/packages/core-bridge/index.d.ts
+++ b/packages/core-bridge/index.d.ts
@@ -78,6 +78,8 @@ export interface CoreOptions {
 export interface TelemetryOptions {
   /** Will be called every time a new batch of spans is exported from core */
   spanBatchCallback: (err: Error, serializedSpanBatch: ArrayBuffer) => void;
+  /** Will be called every time a new batch of metrics is exported from core */
+  metricBatchCallback: (err: Error, serializedMetricsBatch: ArrayBuffer) => void;
 }
 
 export interface WorkerOptions {

--- a/packages/core-bridge/otel.d.ts
+++ b/packages/core-bridge/otel.d.ts
@@ -61,7 +61,6 @@ export interface KVValue {
   F64?: number;
   Bool?: boolean;
   String?: string;
-  // TODO: ugh
   Array?: any;
 }
 

--- a/packages/core-bridge/otel.d.ts
+++ b/packages/core-bridge/otel.d.ts
@@ -1,0 +1,90 @@
+/**
+ *  Contains definitions which correspond to the serde_json serialization of opentelemetry API
+ *  types in Rust
+ */
+
+import Long from 'long';
+
+/**
+ * This is the top-level type representing an exported span. It must correspond with the
+ * `serde_json` serialization of the `SpanData` type in the opentelemetry crate.
+ */
+export interface SerializedSpan {
+  /// Span name
+  name: string;
+  /// Exportable `SpanContext`
+  span_context: SpanContext;
+  /// Span parent id
+  parent_span_id: number;
+  /// Span kind
+  span_kind: string;
+  /// Span start time
+  start_time: SystemTime;
+  /// Span end time
+  end_time: SystemTime;
+  /// Span attributes
+  attributes: {
+    map: {
+      [attributeKey: string]: any;
+    };
+  };
+  /// Span events
+  events: PointlessQueue<Event>;
+  /// Span Links
+  links: PointlessQueue<Link>;
+  /// Span status code
+  status_code: string;
+  /// Span status message
+  status_message: string;
+  /// Resource contains attributes representing an entity that produced this span.
+  resource: {
+    attrs: {
+      [attributeKey: string]: any;
+    };
+  };
+}
+
+export interface SystemTime {
+  secs_since_epoch: number;
+  nanos_since_epoch: number;
+}
+
+export interface SpanContext {
+  trace_id: Long;
+  span_id: Long;
+  trace_flags: number;
+  is_remote: boolean;
+}
+
+export interface KVValue {
+  I64?: number;
+  F64?: number;
+  Bool?: boolean;
+  String?: string;
+  // TODO: ugh
+  Array?: any;
+}
+
+// The serde serialization of the rust OTel types is not done in a way that removes things that
+// are pointless to serialize. This being a prime example.
+export interface PointlessQueue<T> {
+  queue?: T[];
+}
+
+export interface Event {
+  name: string;
+  timestamp: SystemTime;
+  attributes: KeyValue[];
+  dropped_attributes_count: number;
+}
+
+export interface KeyValue {
+  key: string;
+  value: KVValue;
+}
+
+export interface Link {
+  span_context: SpanContext;
+  attributes: KeyValue[];
+  dropped_attributes_count: number;
+}

--- a/packages/core-bridge/package.json
+++ b/packages/core-bridge/package.json
@@ -19,6 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "@temporalio/common": "file:../common",
+    "long": "^4.0.0",
     "cargo-cp-artifact": "^0.1.4"
   },
   "bugs": {

--- a/packages/core-bridge/scripts/build.js
+++ b/packages/core-bridge/scripts/build.js
@@ -43,7 +43,6 @@ function compile(target) {
       'cargo',
       'build',
       '--message-format=json-render-diagnostics',
-      '--release',
       ...(target ? ['--target', target] : []),
     ],
     { stdio: 'inherit' }

--- a/packages/interceptors-opentelemetry/package.json
+++ b/packages/interceptors-opentelemetry/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.0.2",
     "@opentelemetry/exporter-jaeger": "^0.24.0",
+    "@opentelemetry/resources": "^0.24.0",
     "@opentelemetry/sdk-node": "^0.24.0",
     "@temporalio/client": "file:../client",
     "@temporalio/common": "file:../common",

--- a/packages/interceptors-opentelemetry/src/worker/index.ts
+++ b/packages/interceptors-opentelemetry/src/worker/index.ts
@@ -54,7 +54,6 @@ function extractReadableSpan(serializable: SerializableSpan): ReadableSpan {
     spanContext() {
       return spanContext;
     },
-    resource: Resource.EMPTY,
     ...rest,
   };
 }

--- a/packages/interceptors-opentelemetry/src/workflow/interfaces.ts
+++ b/packages/interceptors-opentelemetry/src/workflow/interfaces.ts
@@ -2,6 +2,7 @@ import * as otel from '@opentelemetry/api';
 import * as tracing from '@opentelemetry/tracing';
 import { InstrumentationLibrary } from '@opentelemetry/core';
 import { ExternalDependency, ExternalDependencies } from '@temporalio/workflow';
+import { Resource } from '@opentelemetry/resources';
 
 /**
  * Serializable version of the opentelemetry Span for cross isolate copying
@@ -19,7 +20,7 @@ export interface SerializableSpan {
   readonly events: tracing.TimedEvent[];
   readonly duration: otel.HrTime;
   readonly ended: boolean;
-  // readonly resource: Resource;
+  readonly resource: Resource;
   readonly instrumentationLibrary: InstrumentationLibrary;
 }
 

--- a/packages/interceptors-opentelemetry/src/workflow/span-exporter.ts
+++ b/packages/interceptors-opentelemetry/src/workflow/span-exporter.ts
@@ -29,6 +29,7 @@ export class SpanExporter implements tracing.SpanExporter {
       events: span.events,
       duration: span.duration,
       ended: span.ended,
+      resource: span.resource,
       instrumentationLibrary: span.instrumentationLibrary,
     };
   }

--- a/packages/proto/scripts/compile-proto.js
+++ b/packages/proto/scripts/compile-proto.js
@@ -9,7 +9,8 @@ const pbts = require('protobufjs/cli/pbts');
 const outputDir = resolve(__dirname, '../lib');
 const coresdkJsOutputFile = resolve(outputDir, 'coresdk.js');
 const serviceJsOutputFile = resolve(outputDir, 'temporal.js');
-const protoBaseDir = resolve(__dirname, '../../core-bridge/sdk-core/protos');
+// const protoBaseDir = resolve(__dirname, '../../core-bridge/sdk-core/protos');
+const protoBaseDir = resolve(__dirname, '../../../../sdk-core/protos');
 
 const coreProtoPath = resolve(protoBaseDir, 'local/core_interface.proto');
 const serviceProtoPath = resolve(protoBaseDir, 'api_upstream/temporal/api/workflowservice/v1/service.proto');
@@ -82,7 +83,9 @@ async function main() {
     coresdkJsOutputFile,
     resolve(outputDir, 'coresdk.d.ts'),
     '--path',
-    resolve(protoBaseDir, 'api_upstream')
+    resolve(protoBaseDir, 'api_upstream'),
+    '--path',
+    resolve(protoBaseDir, 'otel')
   );
   await compileProtos(
     serviceProtoPath,

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -27,6 +27,7 @@
     "@temporalio/proto": "file:../proto",
     "@temporalio/worker": "file:../worker",
     "@temporalio/workflow": "file:../workflow",
+    "@opentelemetry/exporter-prometheus": "^0.24.0",
     "ramda": "^0.27.1",
     "uuid": "^8.3.2"
   },

--- a/packages/test/src/activities/index.ts
+++ b/packages/test/src/activities/index.ts
@@ -9,8 +9,11 @@ export { throwSpecificError } from './failure-tester';
 
 // TODO: Get rid of this by providing client via activity context
 function getTestConnection(): Connection {
-  const address = process.env.TEMPORAL_TESTING_SERVER_URL || undefined;
-  return new Connection({ address });
+  const address = process.env.TEMPORAL_TESTING_SERVER_URL;
+  if (address !== undefined) {
+    return new Connection({ address });
+  }
+  return new Connection();
 }
 
 async function sleep(ms: number) {

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -19,6 +19,9 @@
   "license": "MIT",
   "dependencies": {
     "@opentelemetry/api": "^1.0.2",
+    "@opentelemetry/core": "^0.24.0",
+    "@opentelemetry/tracing": "^0.24.0",
+    "@opentelemetry/resources": "^0.24.0",
     "@temporalio/activity": "file:../activity",
     "@temporalio/common": "file:../common",
     "@temporalio/core-bridge": "file:../core-bridge",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -21,6 +21,7 @@
     "@opentelemetry/api": "^1.0.2",
     "@opentelemetry/core": "^0.24.0",
     "@opentelemetry/tracing": "^0.24.0",
+    "@opentelemetry/metrics": "^0.24.0",
     "@opentelemetry/resources": "^0.24.0",
     "@temporalio/activity": "file:../activity",
     "@temporalio/common": "file:../common",

--- a/packages/worker/src/otel_conversion.ts
+++ b/packages/worker/src/otel_conversion.ts
@@ -3,6 +3,27 @@ import { HrTime, Link, SpanAttributes, SpanContext, SpanKind, SpanStatus, SpanSt
 import { Resource, ResourceAttributes } from '@opentelemetry/resources';
 import { hrTimeDuration } from '@opentelemetry/core';
 import { Event, KeyValue, KVValue, Link as CoreLink, SerializedSpan, SystemTime } from '@temporalio/core-bridge/otel';
+import {
+  AggregatorKind,
+  MetricKind,
+  MetricRecord,
+  Point,
+  Sum,
+  SumAggregator,
+  SumAggregatorType,
+} from '@opentelemetry/metrics';
+import { opentelemetry } from '@temporalio/proto/lib/coresdk';
+import { AggregationTemporality, Labels, ValueType } from '@opentelemetry/api-metrics';
+import IMetric = opentelemetry.proto.metrics.v1.IMetric;
+import IInstrumentationLibrary = opentelemetry.proto.common.v1.IInstrumentationLibrary;
+import ProtoAggregationTemporality = opentelemetry.proto.metrics.v1.AggregationTemporality;
+import IStringKeyValue = opentelemetry.proto.common.v1.IStringKeyValue;
+import IResource = opentelemetry.proto.resource.v1.IResource;
+import IKeyValue = opentelemetry.proto.common.v1.IKeyValue;
+import IAnyValue = opentelemetry.proto.common.v1.IAnyValue;
+import NumberDataPoint = opentelemetry.proto.metrics.v1.NumberDataPoint;
+import Long from "long";
+import util from "util";
 
 export function convertRustSpan(span: SerializedSpan): ReadableSpan {
   const status: SpanStatus = {
@@ -34,8 +55,110 @@ export function convertRustSpan(span: SerializedSpan): ReadableSpan {
   };
 }
 
+class FixedSumAgg implements SumAggregatorType {
+  kind: AggregatorKind.SUM = AggregatorKind.SUM;
+  val: number;
+  time: HrTime;
+
+  constructor(val: number, time: HrTime) {
+    this.val = val;
+    this.time = time;
+  }
+
+  toPoint(): Point<Sum> {
+    return {
+      value: this.val,
+      timestamp: this.time
+    }
+  }
+
+  update(_: number): void {}
+}
+
+export function convertRustMetric(metric: IMetric, il: IInstrumentationLibrary, rsc: IResource): MetricRecord {
+  // TODO: How do I type this part better?
+  let record: any = {
+    descriptor: {
+      description: metric.description || '',
+      name: metric.name || '',
+      unit: metric.unit || '',
+    },
+  };
+
+  // AKA attributes, labels deprecated
+  // There just seems to be a fundamental incompatibility going this direction, where the protos
+  // can have more than one data point, each with it's own set of labels, where a MetricRecord
+  // has only one set of labels.
+  let labels: Labels = {};
+
+  if (metric.sum != null) {
+    if (metric.sum.isMonotonic) {
+      record.descriptor.metricKind = MetricKind.SUM_OBSERVER;
+    } else {
+      record.descriptor.metricKind = MetricKind.UP_DOWN_SUM_OBSERVER;
+    }
+    record.descriptor.valueType = ValueType.DOUBLE;
+    record.aggregationTemporality = protoAgTemporailty(metric.sum.aggregationTemporality);
+    const mdp = (metric.sum.dataPoints || []).map((ndp) => new NumberDataPoint(ndp));
+    console.log(util.inspect(mdp, false, null, true ))
+    const agg = new FixedSumAgg(mdp[0].asInt?.toNumber() || 0, nanoLongToHrTime(mdp[0].timeUnixNano));
+    record.aggregator = agg;
+  } else if (metric.intSum != null) {
+    if (metric.intSum.isMonotonic) {
+      record.descriptor.metricKind = MetricKind.SUM_OBSERVER;
+    } else {
+      record.descriptor.metricKind = MetricKind.UP_DOWN_SUM_OBSERVER;
+    }
+    record.descriptor.valueType = ValueType.INT;
+    record.aggregationTemporality = protoAgTemporailty(metric.intSum.aggregationTemporality);
+  } else if (metric.gauge != null) {
+    record.descriptor.metricKind = MetricKind.UP_DOWN_COUNTER;
+    record.descriptor.valueType = ValueType.DOUBLE;
+    record.aggregator.kind = AggregatorKind.LAST_VALUE;
+  } else if (metric.intGauge != null) {
+    record.descriptor.metricKind = MetricKind.UP_DOWN_COUNTER;
+    record.descriptor.valueType = ValueType.INT;
+    record.aggregator.kind = AggregatorKind.LAST_VALUE;
+  } else if (metric.intHistogram != null) {
+    record.descriptor.metricKind = MetricKind.VALUE_OBSERVER;
+    record.descriptor.valueType = ValueType.INT;
+    record.aggregator.kind = AggregatorKind.HISTOGRAM;
+  } else if (metric.histogram != null) {
+    record.descriptor.metricKind = MetricKind.VALUE_OBSERVER;
+    record.descriptor.valueType = ValueType.DOUBLE;
+    record.aggregator.kind = AggregatorKind.HISTOGRAM;
+  } else if (metric.summary != null) {
+    record.descriptor.metricKind = MetricKind.VALUE_RECORDER;
+    record.descriptor.valueType = ValueType.DOUBLE;
+    record.aggregator.kind = AggregatorKind.HISTOGRAM;
+  }
+
+  return {
+    aggregationTemporality: AggregationTemporality.AGGREGATION_TEMPORALITY_UNSPECIFIED,
+    instrumentationLibrary: { name: 'temporal-sdk-core-exporter' },
+    resource: protoResource(rsc),
+    labels: labels,
+    ...record,
+  };
+}
+
 function time(time: SystemTime): HrTime {
   return [time.secs_since_epoch, time.nanos_since_epoch];
+}
+
+const NANOSECOND_DIGITS = 9;
+const SECOND_TO_NANOSECONDS = Math.pow(10, NANOSECOND_DIGITS);
+function nanoLongToHrTime(nanos: Long): HrTime {
+  // From upstream:
+  // export function hrTimeToNanoseconds(hrTime: api.HrTime): number {
+  //   return hrTime[0] * SECOND_TO_NANOSECONDS + hrTime[1];
+  // }
+
+  // IE: Hr time first element is the nanoseconds portion of the time, and the second element is
+  //   the remaining time in seconds;
+  const secondsPortion = nanos.divide(SECOND_TO_NANOSECONDS);
+  const nanoPortion = nanos.sub(secondsPortion.mul(SECOND_TO_NANOSECONDS));
+  return [secondsPortion.toNumber(), nanoPortion.toNumber()];
 }
 
 function id(id: Long | number): string {
@@ -90,7 +213,19 @@ function resource(resource: SerializedSpan['resource']): Resource {
   return {
     attributes: kvMapping(resource.attrs) as ResourceAttributes,
     merge(r: Resource | null): Resource {
-      if (r !== null) {
+      if (r != null) {
+        Object.assign(this.attributes, r.attributes);
+      }
+      return this;
+    },
+  };
+}
+
+function protoResource(resource: IResource | null | undefined): Resource {
+  return {
+    attributes: protoKvArrToResourceAttribs(resource?.attributes || []),
+    merge(r: Resource | null): Resource {
+      if (r != null) {
         Object.assign(this.attributes, r.attributes);
       }
       return this;
@@ -134,4 +269,51 @@ function link(link: CoreLink): Link {
     attributes: vecAttributes(link.attributes),
     context: context(link.span_context),
   };
+}
+
+function protoAgTemporailty(agtemp: ProtoAggregationTemporality | null | undefined): AggregationTemporality {
+  if (agtemp === ProtoAggregationTemporality.AGGREGATION_TEMPORALITY_DELTA) {
+    return AggregationTemporality.AGGREGATION_TEMPORALITY_DELTA;
+  } else if (agtemp === ProtoAggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE) {
+    return AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE;
+  }
+  return AggregationTemporality.AGGREGATION_TEMPORALITY_UNSPECIFIED;
+}
+
+function protoToLabels(labels: IStringKeyValue[]): Labels {
+  const retme: { [key: string]: string } = {};
+  for (const kv of labels) {
+    if (kv.key && kv.value) {
+      retme[kv.key] = kv.value;
+    }
+  }
+  return retme;
+}
+
+function protoKvArrToResourceAttribs(kvArr: IKeyValue[]): ResourceAttributes {
+  const retme: ResourceAttributes = {};
+  for (const kv of kvArr) {
+    const asval = protoAnyValToNSB(kv.value);
+    if (kv.key && asval != null) {
+      retme[kv.key] = asval;
+    }
+  }
+  return retme;
+}
+
+function protoAnyValToNSB(val: IAnyValue | null | undefined): string | number | boolean | null {
+  if (val == null) {
+    return null;
+  }
+  if (val.boolValue != null) {
+    return val.boolValue;
+  } else if (val.stringValue != null) {
+    return val.stringValue;
+  } else if (val.intValue != null) {
+    return val.intValue.toNumber();
+  } else if (val.doubleValue != null) {
+    return val.doubleValue;
+  }
+  // These values can't be handled properly
+  return null;
 }

--- a/packages/worker/src/otel_conversion.ts
+++ b/packages/worker/src/otel_conversion.ts
@@ -1,0 +1,137 @@
+import { ReadableSpan, TimedEvent } from '@opentelemetry/tracing';
+import { HrTime, Link, SpanAttributes, SpanContext, SpanKind, SpanStatus, SpanStatusCode } from '@opentelemetry/api';
+import { Resource, ResourceAttributes } from '@opentelemetry/resources';
+import { hrTimeDuration } from '@opentelemetry/core';
+import { Event, KeyValue, KVValue, Link as CoreLink, SerializedSpan, SystemTime } from '@temporalio/core-bridge/otel';
+
+export function convertRustSpan(span: SerializedSpan): ReadableSpan {
+  const status: SpanStatus = {
+    code: statusCode(span.status_code),
+    message: span.status_message,
+  };
+  const startTime = time(span.start_time);
+  const endTime = time(span.end_time);
+  const duration: HrTime = endTime[1] === 0 ? [0, 0] : hrTimeDuration(startTime, endTime);
+  return {
+    attributes: attributes(span.attributes),
+    duration,
+    startTime,
+    endTime,
+    ended: span.end_time.nanos_since_epoch !== 0,
+    events: span.events.queue?.map(event) || [],
+    instrumentationLibrary: {
+      name: 'temporal-sdk-core-exporter',
+    },
+    kind: kind(span.span_kind),
+    links: span.links.queue?.map(link) || [],
+    name: span.name,
+    parentSpanId: id(span.parent_span_id),
+    resource: resource(span.resource),
+    spanContext(): SpanContext {
+      return context(span.span_context);
+    },
+    status,
+  };
+}
+
+function time(time: SystemTime): HrTime {
+  return [time.secs_since_epoch, time.nanos_since_epoch];
+}
+
+function id(id: Long | number): string {
+  // Hex repr for ids
+  return id.toString(16);
+}
+
+function statusCode(code: string): SpanStatusCode {
+  if (code === 'Ok') {
+    return SpanStatusCode.OK;
+  } else if (code === 'Error') {
+    return SpanStatusCode.ERROR;
+  }
+  return SpanStatusCode.UNSET;
+}
+
+function attributes(attrs: SerializedSpan['attributes']): SpanAttributes {
+  return kvMapping(attrs.map) as SpanAttributes;
+}
+
+function vecAttributes(attrs: KeyValue[]): SpanAttributes {
+  const retme: SpanAttributes = {};
+  for (const kv of attrs) {
+    retme[kv.key] = kvVal(kv.value);
+  }
+  return retme;
+}
+
+function kind(kind: string): SpanKind {
+  if (kind === 'Client') {
+    return SpanKind.CLIENT;
+  } else if (kind === 'Server') {
+    return SpanKind.SERVER;
+  } else if (kind === 'Consumer') {
+    return SpanKind.CONSUMER;
+  } else if (kind === 'Producer') {
+    return SpanKind.PRODUCER;
+  }
+  return SpanKind.INTERNAL;
+}
+
+function context(ctx: SerializedSpan['span_context']): SpanContext {
+  return {
+    spanId: id(ctx.span_id),
+    traceFlags: ctx.trace_flags,
+    traceId: id(ctx.trace_id),
+    isRemote: ctx.is_remote,
+  };
+}
+
+function resource(resource: SerializedSpan['resource']): Resource {
+  return {
+    attributes: kvMapping(resource.attrs) as ResourceAttributes,
+    merge(r: Resource | null): Resource {
+      if (r !== null) {
+        Object.assign(this.attributes, r.attributes);
+      }
+      return this;
+    },
+  };
+}
+
+function kvMapping(mapping: { [key: string]: KVValue }): any {
+  const retme: { [key: string]: any } = {};
+  Object.keys(mapping).map(function (key, _) {
+    retme[key] = kvVal(mapping[key]);
+  });
+  return retme;
+}
+
+function kvVal(val: KVValue): string | number | boolean {
+  if (val.I64 !== undefined) {
+    return val.I64;
+  } else if (val.F64 !== undefined) {
+    return val.F64;
+  } else if (val.Bool !== undefined) {
+    return val.Bool;
+  } else if (val.String !== undefined) {
+    return val.String;
+  } else if (val.Array !== undefined) {
+    return JSON.stringify(val.Array);
+  }
+  return 'unparseable';
+}
+
+function event(event: Event): TimedEvent {
+  return {
+    attributes: vecAttributes(event.attributes),
+    name: event.name,
+    time: time(event.timestamp),
+  };
+}
+
+function link(link: CoreLink): Link {
+  return {
+    attributes: vecAttributes(link.attributes),
+    context: context(link.span_context),
+  };
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Allows us to export spans and metrics from core using the OTel collector format and then read them in node and re-export them to the user's specified exporters

## Why?
Unification of spans/metrics without needing a separate process

## Checklist
<!--- add/delete as needed --->

1. See https://github.com/temporalio/sdk-core/issues/85 -- is one half of that
 
2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
