### PR TITLE
chore: Add algolia search to API reference

### DIFF
--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -84,6 +84,11 @@ module.exports = {
       // Optional fields.
       anonymizeIP: true, // Should IPs be anonymized?
     },
+    algolia: {
+      apiKey: 'f0437b275747f3b6bd2cff61e1e3a796',
+      indexName: 'nodejs-temporal',
+      algoliaOptions: { facetFilters: ['type:$TYPE'] },
+    },
   },
   presets: [
     [


### PR DESCRIPTION
Closes #115

Got an Algolia docsearch API key.

Configuration can be found here: https://github.com/algolia/docsearch-configs/blob/master/configs/nodejs-temporal.json