### PR TITLE
feat(workflow)!: Process Workflow activations concurrently

### DIFF
--- a/packages/interceptors-opentelemetry/src/workflow/index.ts
+++ b/packages/interceptors-opentelemetry/src/workflow/index.ts
@@ -6,7 +6,7 @@ import {
   Next,
   WorkflowInboundCallsInterceptor,
   WorkflowOutboundCallsInterceptor,
-  WorkflowInput,
+  WorkflowExecuteInput,
 } from '@temporalio/workflow';
 import { defaultDataConverter } from '@temporalio/common';
 import { instrument, instrumentFromSpanContext } from '../instrumentation';
@@ -37,7 +37,10 @@ export function registerOpentelemetryTracerProvider(): void {
  * provided in the Workflow input headers.
  */
 export class OpenTelemetryInboundInterceptor implements WorkflowInboundCallsInterceptor {
-  public async execute(input: WorkflowInput, next: Next<WorkflowInboundCallsInterceptor, 'execute'>): Promise<unknown> {
+  public async execute(
+    input: WorkflowExecuteInput,
+    next: Next<WorkflowInboundCallsInterceptor, 'execute'>
+  ): Promise<unknown> {
     const encodedSpanContext = input.headers.get(TRACE_HEADER);
     const spanContext: otel.SpanContext | undefined = encodedSpanContext
       ? await defaultDataConverter.fromPayload(encodedSpanContext)

--- a/packages/test/src/interfaces/index.ts
+++ b/packages/test/src/interfaces/index.ts
@@ -111,3 +111,10 @@ export type Blocked = () => {
   };
 };
 // @@@SNIPEND
+
+export type Gated = () => {
+  execute(): Promise<void>;
+  signals: {
+    someShallPass(): void;
+  };
+};

--- a/packages/test/src/test-workflows.ts
+++ b/packages/test/src/test-workflows.ts
@@ -13,9 +13,9 @@ import * as activityFunctions from './activities';
 import { u8 } from './helpers';
 
 export interface Context {
-  workflow: Workflow;
+  workflow?: Workflow;
   logs: unknown[][];
-  script: string;
+  workflowType: string;
   contextProvider: RoundRobinIsolateContextProvider;
 }
 
@@ -37,6 +37,14 @@ test.beforeEach(async (t) => {
   const { contextProvider } = t.context;
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const testName = t.title.match(/\S+$/)![0];
+  const logs: unknown[][] = [];
+  t.context = { logs, workflowType: testName, contextProvider };
+});
+
+async function createWorkflow(t: ExecutionContext<Context>, startWorkflow: coresdk.workflow_activation.IStartWorkflow) {
+  const { logs, contextProvider } = t.context;
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const testName = t.title.match(/\S+$/)![0];
   const workflow = await Workflow.create(
     await contextProvider.getContext(),
     {
@@ -49,17 +57,26 @@ test.beforeEach(async (t) => {
     },
     [],
     Long.fromInt(1337),
+    startWorkflow,
     100
   );
-  const logs: unknown[][] = [];
   await workflow.injectGlobal('console.log', (...args: unknown[]) => void logs.push(args), ApplyMode.SYNC);
-  t.context = { workflow, logs, script: testName, contextProvider };
-});
+  return workflow;
+}
 
 async function activate(t: ExecutionContext<Context>, activation: coresdk.workflow_activation.IWFActivation) {
-  const arr = await t.context.workflow.activate(activation);
+  let workflow = t.context.workflow;
+  if (workflow === undefined) {
+    const [{ startWorkflow }] = activation.jobs ?? [{}];
+    if (!startWorkflow) {
+      throw new TypeError('Expected first activation job to be startWorkflow');
+    }
+    workflow = await createWorkflow(t, startWorkflow);
+    t.context.workflow = workflow;
+  }
+  const arr = await workflow.activate(activation);
   const completion = coresdk.workflow_completion.WFActivationCompletion.decodeDelimited(arr);
-  t.deepEqual(completion.runId, t.context.workflow.info.runId);
+  t.deepEqual(completion.runId, workflow.info.runId);
   return completion;
 }
 
@@ -72,7 +89,7 @@ function compareCompletion(
     req.toJSON(),
     new coresdk.workflow_completion.WFActivationCompletion({
       ...expected,
-      runId: t.context.workflow.info.runId,
+      runId: t.context.workflow?.info.runId,
     }).toJSON()
   );
 }
@@ -92,11 +109,11 @@ function makeStartWorkflow(
 }
 
 function makeStartWorkflowJob(
-  script: string,
+  workflowType: string,
   args?: coresdk.common.IPayload[]
-): coresdk.workflow_activation.IWFActivationJob {
+): { startWorkflow: coresdk.workflow_activation.IStartWorkflow } {
   return {
-    startWorkflow: { workflowId: 'test-workflowId', workflowType: script, arguments: args },
+    startWorkflow: { workflowId: 'test-workflowId', workflowType, arguments: args },
   };
 }
 
@@ -260,9 +277,9 @@ function makeSetPatchMarker(myPatchId: string, deprecated: boolean): coresdk.wor
 }
 
 test('random', async (t) => {
-  const { logs, script } = t.context;
+  const { logs, workflowType } = t.context;
   {
-    const req = await activate(t, makeStartWorkflow(script));
+    const req = await activate(t, makeStartWorkflow(workflowType));
     compareCompletion(t, req, makeSuccess([makeStartTimerCommand({ seq: 1, startToFireTimeout: msToTs(1) })]));
   }
   {
@@ -280,8 +297,8 @@ test('random', async (t) => {
 });
 
 test('successString', async (t) => {
-  const { script } = t.context;
-  const req = await activate(t, makeStartWorkflow(script));
+  const { workflowType } = t.context;
+  const req = await activate(t, makeStartWorkflow(workflowType));
   compareCompletion(
     t,
     req,
@@ -318,8 +335,8 @@ function cleanWorkflowQueryFailureStackTrace(
 }
 
 test('throwAsync', async (t) => {
-  const { script } = t.context;
-  const req = cleanWorkflowFailureStackTrace(await activate(t, makeStartWorkflow(script)));
+  const { workflowType } = t.context;
+  const req = cleanWorkflowFailureStackTrace(await activate(t, makeStartWorkflow(workflowType)));
   compareCompletion(
     t,
     req,
@@ -336,30 +353,30 @@ test('throwAsync', async (t) => {
 });
 
 test('date', async (t) => {
-  const { logs, script } = t.context;
+  const { logs, workflowType } = t.context;
   const now = Date.now();
-  const req = await activate(t, makeStartWorkflow(script, undefined, now));
+  const req = await activate(t, makeStartWorkflow(workflowType, undefined, now));
   compareCompletion(t, req, makeSuccess());
   t.deepEqual(logs, [[now], [now], [true]]);
 });
 
 test('asyncWorkflow', async (t) => {
-  const { script } = t.context;
-  const req = await activate(t, makeStartWorkflow(script));
+  const { workflowType } = t.context;
+  const req = await activate(t, makeStartWorkflow(workflowType));
   compareCompletion(t, req, makeSuccess([makeCompleteWorkflowExecution(defaultDataConverter.toPayloadSync('async'))]));
 });
 
 test('deferredResolve', async (t) => {
-  const { logs, script } = t.context;
-  const req = await activate(t, makeStartWorkflow(script));
+  const { logs, workflowType } = t.context;
+  const req = await activate(t, makeStartWorkflow(workflowType));
   compareCompletion(t, req, makeSuccess());
   t.deepEqual(logs, [[1], [2]]);
 });
 
 test('sleeper', async (t) => {
-  const { logs, script } = t.context;
+  const { logs, workflowType } = t.context;
   {
-    const req = await activate(t, makeStartWorkflow(script));
+    const req = await activate(t, makeStartWorkflow(workflowType));
     compareCompletion(t, req, makeSuccess([makeStartTimerCommand({ seq: 1, startToFireTimeout: msToTs(100) })]));
   }
   {
@@ -370,9 +387,9 @@ test('sleeper', async (t) => {
 });
 
 test('setTimeoutAfterMicroTasks', async (t) => {
-  const { logs, script } = t.context;
+  const { logs, workflowType } = t.context;
   {
-    const req = await activate(t, makeStartWorkflow(script));
+    const req = await activate(t, makeStartWorkflow(workflowType));
     compareCompletion(t, req, makeSuccess([makeStartTimerCommand({ seq: 1, startToFireTimeout: msToTs(100) })]));
   }
   {
@@ -383,30 +400,30 @@ test('setTimeoutAfterMicroTasks', async (t) => {
 });
 
 test('promiseThenPromise', async (t) => {
-  const { logs, script } = t.context;
-  const req = await activate(t, makeStartWorkflow(script));
+  const { logs, workflowType } = t.context;
+  const req = await activate(t, makeStartWorkflow(workflowType));
   compareCompletion(t, req, makeSuccess());
   t.deepEqual(logs, [[2]]);
 });
 
 test('rejectPromise', async (t) => {
-  const { logs, script } = t.context;
-  const req = await activate(t, makeStartWorkflow(script));
+  const { logs, workflowType } = t.context;
+  const req = await activate(t, makeStartWorkflow(workflowType));
   compareCompletion(t, req, makeSuccess());
   t.deepEqual(logs, [[true], [true]]);
 });
 
 test('promiseAll', async (t) => {
-  const { logs, script } = t.context;
-  const req = await activate(t, makeStartWorkflow(script));
+  const { logs, workflowType } = t.context;
+  const req = await activate(t, makeStartWorkflow(workflowType));
   compareCompletion(t, req, makeSuccess());
   t.deepEqual(logs, [[1, 2, 3], [1, 2, 3], [1, 2, 3], ['wow']]);
 });
 
 test('tasksAndMicrotasks', async (t) => {
-  const { logs, script } = t.context;
+  const { logs, workflowType } = t.context;
   {
-    const req = await activate(t, makeStartWorkflow(script));
+    const req = await activate(t, makeStartWorkflow(workflowType));
     compareCompletion(t, req, makeSuccess([makeStartTimerCommand({ seq: 1, startToFireTimeout: msToTs(0) })]));
   }
   {
@@ -417,12 +434,12 @@ test('tasksAndMicrotasks', async (t) => {
 });
 
 test('trailingTimer', async (t) => {
-  const { logs, script } = t.context;
+  const { logs, workflowType } = t.context;
   {
-    const req = await activate(t, makeStartWorkflow(script));
+    const completion = await activate(t, makeStartWorkflow(workflowType));
     compareCompletion(
       t,
-      req,
+      completion,
       makeSuccess([
         makeStartTimerCommand({ seq: 1, startToFireTimeout: msToTs(1) }),
         makeStartTimerCommand({ seq: 2, startToFireTimeout: msToTs(1) }),
@@ -430,22 +447,25 @@ test('trailingTimer', async (t) => {
     );
   }
   {
-    const req = await activate(t, makeActivation(undefined, makeFireTimerJob(1), makeFireTimerJob(2)));
+    const completion = await activate(t, makeActivation(undefined, makeFireTimerJob(1), makeFireTimerJob(2)));
     // Note that the trailing timer does not get scheduled since the workflow completes
     // after the first timer is triggered causing the second one to be dropped.
     compareCompletion(
       t,
-      req,
-      makeSuccess([makeCompleteWorkflowExecution(await defaultDataConverter.toPayload('first'))])
+      completion,
+      makeSuccess([
+        makeStartTimerCommand({ seq: 3, startToFireTimeout: msToTs(0) }),
+        makeCompleteWorkflowExecution(await defaultDataConverter.toPayload('first')),
+      ])
     );
   }
   t.deepEqual(logs, []);
 });
 
 test('promiseRace', async (t) => {
-  const { logs, script } = t.context;
+  const { logs, workflowType } = t.context;
   {
-    const req = await activate(t, makeStartWorkflow(script));
+    const req = await activate(t, makeStartWorkflow(workflowType));
     compareCompletion(
       t,
       req,
@@ -463,9 +483,9 @@ test('promiseRace', async (t) => {
 });
 
 test('race', async (t) => {
-  const { logs, script } = t.context;
+  const { logs, workflowType } = t.context;
   {
-    const req = await activate(t, makeStartWorkflow(script));
+    const req = await activate(t, makeStartWorkflow(workflowType));
     compareCompletion(
       t,
       req,
@@ -487,9 +507,9 @@ test('race', async (t) => {
 });
 
 test('importer', async (t) => {
-  const { logs, script } = t.context;
+  const { logs, workflowType } = t.context;
   {
-    const req = await activate(t, makeStartWorkflow(script));
+    const req = await activate(t, makeStartWorkflow(workflowType));
     compareCompletion(t, req, makeSuccess([makeStartTimerCommand({ seq: 1, startToFireTimeout: msToTs(10) })]));
   }
   {
@@ -500,17 +520,17 @@ test('importer', async (t) => {
 });
 
 test('externalImporter', async (t) => {
-  const { logs, script } = t.context;
-  const req = await activate(t, makeStartWorkflow(script));
+  const { logs, workflowType } = t.context;
+  const req = await activate(t, makeStartWorkflow(workflowType));
   compareCompletion(t, req, makeSuccess());
   t.deepEqual(logs, [[{ a: 1, b: 2 }]]);
 });
 
 test('argsAndReturn', async (t) => {
-  const { script } = t.context;
+  const { workflowType } = t.context;
   const req = await activate(
     t,
-    makeStartWorkflow(script, [
+    makeStartWorkflow(workflowType, [
       {
         metadata: { encoding: u8('json/plain') },
         data: u8(JSON.stringify('Hello')),
@@ -537,9 +557,9 @@ test('argsAndReturn', async (t) => {
 });
 
 test('invalidOrFailedQueries', async (t) => {
-  const { script } = t.context;
+  const { workflowType } = t.context;
   {
-    const completion = await activate(t, makeStartWorkflow(script));
+    const completion = await activate(t, makeStartWorkflow(workflowType));
     compareCompletion(t, completion, makeSuccess());
   }
   {
@@ -594,9 +614,9 @@ test('invalidOrFailedQueries', async (t) => {
 });
 
 test('interruptSignal', async (t) => {
-  const { script } = t.context;
+  const { workflowType } = t.context;
   {
-    const req = await activate(t, makeStartWorkflow(script));
+    const req = await activate(t, makeStartWorkflow(workflowType));
     compareCompletion(t, req, makeSuccess([]));
   }
   {
@@ -623,9 +643,9 @@ test('interruptSignal', async (t) => {
 });
 
 test('failSignal', async (t) => {
-  const { script } = t.context;
+  const { workflowType } = t.context;
   {
-    const req = await activate(t, makeStartWorkflow(script));
+    const req = await activate(t, makeStartWorkflow(workflowType));
     compareCompletion(t, req, makeSuccess([makeStartTimerCommand({ seq: 1, startToFireTimeout: msToTs(100000) })]));
   }
   {
@@ -648,9 +668,9 @@ test('failSignal', async (t) => {
 });
 
 test('asyncFailSignal', async (t) => {
-  const { script } = t.context;
+  const { workflowType } = t.context;
   {
-    const req = await activate(t, makeStartWorkflow(script));
+    const req = await activate(t, makeStartWorkflow(workflowType));
     compareCompletion(t, req, makeSuccess([makeStartTimerCommand({ seq: 1, startToFireTimeout: msToTs(100000) })]));
   }
   {
@@ -677,9 +697,9 @@ test('asyncFailSignal', async (t) => {
 
 test('cancelWorkflow', async (t) => {
   const url = 'https://temporal.io';
-  const { script } = t.context;
+  const { workflowType } = t.context;
   {
-    const req = await activate(t, makeStartWorkflow(script, await defaultDataConverter.toPayloads(url)));
+    const req = await activate(t, makeStartWorkflow(workflowType, await defaultDataConverter.toPayloads(url)));
     compareCompletion(
       t,
       req,
@@ -744,9 +764,9 @@ test('cancelWorkflow', async (t) => {
 });
 
 test('cancel - unblockOrCancel', async (t) => {
-  const { script, logs } = t.context;
+  const { workflowType, logs } = t.context;
   {
-    const completion = await activate(t, makeStartWorkflow(script));
+    const completion = await activate(t, makeStartWorkflow(workflowType));
     compareCompletion(t, completion, makeSuccess([]));
   }
   {
@@ -757,9 +777,9 @@ test('cancel - unblockOrCancel', async (t) => {
 });
 
 test('unblock - unblockOrCancel', async (t) => {
-  const { script } = t.context;
+  const { workflowType } = t.context;
   {
-    const completion = await activate(t, makeStartWorkflow(script));
+    const completion = await activate(t, makeStartWorkflow(workflowType));
     compareCompletion(t, completion, makeSuccess([]));
   }
   {
@@ -795,8 +815,8 @@ test('unblock - unblockOrCancel', async (t) => {
 });
 
 test('cancelTimer', async (t) => {
-  const { script, logs } = t.context;
-  const req = await activate(t, makeStartWorkflow(script));
+  const { workflowType, logs } = t.context;
+  const req = await activate(t, makeStartWorkflow(workflowType));
   compareCompletion(
     t,
     req,
@@ -810,8 +830,8 @@ test('cancelTimer', async (t) => {
 });
 
 test('cancelTimerAltImpl', async (t) => {
-  const { script, logs } = t.context;
-  const req = await activate(t, makeStartWorkflow(script));
+  const { workflowType, logs } = t.context;
+  const req = await activate(t, makeStartWorkflow(workflowType));
   compareCompletion(
     t,
     req,
@@ -825,11 +845,11 @@ test('cancelTimerAltImpl', async (t) => {
 });
 
 test('nonCancellable', async (t) => {
-  const { script } = t.context;
+  const { workflowType } = t.context;
   const url = 'https://temporal.io';
   const result = await defaultDataConverter.toPayload({ test: true });
   {
-    const completion = await activate(t, makeStartWorkflow(script, [await defaultDataConverter.toPayload(url)]));
+    const completion = await activate(t, makeStartWorkflow(workflowType, [await defaultDataConverter.toPayload(url)]));
     compareCompletion(
       t,
       completion,
@@ -852,11 +872,11 @@ test('nonCancellable', async (t) => {
 });
 
 test('resumeAfterCancellation', async (t) => {
-  const { script } = t.context;
+  const { workflowType } = t.context;
   const url = 'https://temporal.io';
   const result = await defaultDataConverter.toPayload({ test: true });
   {
-    const completion = await activate(t, makeStartWorkflow(script, [await defaultDataConverter.toPayload(url)]));
+    const completion = await activate(t, makeStartWorkflow(workflowType, [await defaultDataConverter.toPayload(url)]));
     compareCompletion(
       t,
       completion,
@@ -883,12 +903,15 @@ test('resumeAfterCancellation', async (t) => {
 });
 
 test('handleExternalWorkflowCancellationWhileActivityRunning', async (t) => {
-  const { script } = t.context;
+  const { workflowType } = t.context;
   const url = 'https://temporal.io';
   const data = { content: 'new HTML content' };
   {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const completion = await activate(t, makeStartWorkflow(script, await defaultDataConverter.toPayloads(url, data)!));
+    const completion = await activate(
+      t,
+      makeStartWorkflow(workflowType, (await defaultDataConverter.toPayloads(url, data)) ?? [])
+    );
 
     compareCompletion(
       t,
@@ -939,10 +962,10 @@ test('handleExternalWorkflowCancellationWhileActivityRunning', async (t) => {
 });
 
 test('nestedCancellation', async (t) => {
-  const { script } = t.context;
+  const { workflowType } = t.context;
   const url = 'https://temporal.io';
   {
-    const completion = await activate(t, makeStartWorkflow(script, [await defaultDataConverter.toPayload(url)]));
+    const completion = await activate(t, makeStartWorkflow(workflowType, [await defaultDataConverter.toPayload(url)]));
 
     compareCompletion(
       t,
@@ -1020,10 +1043,10 @@ test('nestedCancellation', async (t) => {
 });
 
 test('sharedScopes', async (t) => {
-  const { script } = t.context;
+  const { workflowType } = t.context;
   const result = { some: 'data' };
   {
-    const completion = await activate(t, makeStartWorkflow(script));
+    const completion = await activate(t, makeStartWorkflow(workflowType));
     compareCompletion(
       t,
       completion,
@@ -1057,10 +1080,10 @@ test('sharedScopes', async (t) => {
 });
 
 test('shieldAwaitedInRootScope', async (t) => {
-  const { script } = t.context;
+  const { workflowType } = t.context;
   const result = { some: 'data' };
   {
-    const completion = await activate(t, makeStartWorkflow(script));
+    const completion = await activate(t, makeStartWorkflow(workflowType));
     compareCompletion(
       t,
       completion,
@@ -1095,9 +1118,9 @@ test('shieldAwaitedInRootScope', async (t) => {
 });
 
 test('cancellationScopesWithCallbacks', async (t) => {
-  const { script } = t.context;
+  const { workflowType } = t.context;
   {
-    const completion = await activate(t, makeStartWorkflow(script));
+    const completion = await activate(t, makeStartWorkflow(workflowType));
     compareCompletion(t, completion, makeSuccess([makeStartTimerCommand({ seq: 1, startToFireTimeout: msToTs(10) })]));
   }
   {
@@ -1107,9 +1130,9 @@ test('cancellationScopesWithCallbacks', async (t) => {
 });
 
 test('cancellationScopes', async (t) => {
-  const { script, logs } = t.context;
+  const { workflowType, logs } = t.context;
   {
-    const req = await activate(t, makeStartWorkflow(script));
+    const req = await activate(t, makeStartWorkflow(workflowType));
     compareCompletion(t, req, makeSuccess([makeStartTimerCommand({ seq: 1, startToFireTimeout: msToTs(3) })]));
   }
   {
@@ -1142,9 +1165,9 @@ test('cancellationScopes', async (t) => {
 });
 
 test('childAndShield', async (t) => {
-  const { script } = t.context;
+  const { workflowType } = t.context;
   {
-    const req = await activate(t, makeStartWorkflow(script));
+    const req = await activate(t, makeStartWorkflow(workflowType));
     compareCompletion(t, req, makeSuccess([makeStartTimerCommand({ seq: 1, startToFireTimeout: msToTs(5) })]));
   }
   {
@@ -1154,9 +1177,9 @@ test('childAndShield', async (t) => {
 });
 
 test('partialShield', async (t) => {
-  const { script, logs } = t.context;
+  const { workflowType, logs } = t.context;
   {
-    const req = await activate(t, makeStartWorkflow(script));
+    const req = await activate(t, makeStartWorkflow(workflowType));
     compareCompletion(
       t,
       req,
@@ -1193,9 +1216,9 @@ test('partialShield', async (t) => {
 });
 
 test('shieldInShield', async (t) => {
-  const { script, logs } = t.context;
+  const { workflowType, logs } = t.context;
   {
-    const req = await activate(t, makeStartWorkflow(script));
+    const req = await activate(t, makeStartWorkflow(workflowType));
     compareCompletion(
       t,
       req,
@@ -1217,8 +1240,8 @@ test('shieldInShield', async (t) => {
 });
 
 test('cancellationErrorIsPropagated', async (t) => {
-  const { script, logs } = t.context;
-  const req = cleanWorkflowFailureStackTrace(await activate(t, makeStartWorkflow(script)), 2);
+  const { workflowType, logs } = t.context;
+  const req = cleanWorkflowFailureStackTrace(await activate(t, makeStartWorkflow(workflowType)), 2);
   compareCompletion(
     t,
     req,
@@ -1251,9 +1274,9 @@ test('cancellationErrorIsPropagated', async (t) => {
 
 test('cancelActivityAfterFirstCompletion', async (t) => {
   const url = 'https://temporal.io';
-  const { script, logs } = t.context;
+  const { workflowType, logs } = t.context;
   {
-    const req = await activate(t, makeStartWorkflow(script, await defaultDataConverter.toPayloads(url)));
+    const req = await activate(t, makeStartWorkflow(workflowType, await defaultDataConverter.toPayloads(url)));
     compareCompletion(
       t,
       req,
@@ -1309,9 +1332,12 @@ test('cancelActivityAfterFirstCompletion', async (t) => {
 
 test('multipleActivitiesSingleTimeout', async (t) => {
   const urls = ['https://slow-site.com/', 'https://slow-site.org/'];
-  const { script } = t.context;
+  const { workflowType } = t.context;
   {
-    const completion = await activate(t, makeStartWorkflow(script, await defaultDataConverter.toPayloads(urls, 1000)));
+    const completion = await activate(
+      t,
+      makeStartWorkflow(workflowType, await defaultDataConverter.toPayloads(urls, 1000))
+    );
     compareCompletion(
       t,
       completion,
@@ -1352,9 +1378,9 @@ test('multipleActivitiesSingleTimeout', async (t) => {
 });
 
 test('resolve activity with result - http', async (t) => {
-  const { script } = t.context;
+  const { workflowType } = t.context;
   {
-    const completion = await activate(t, makeStartWorkflow(script));
+    const completion = await activate(t, makeStartWorkflow(workflowType));
     compareCompletion(
       t,
       completion,
@@ -1386,9 +1412,9 @@ test('resolve activity with result - http', async (t) => {
 });
 
 test('resolve activity with failure - http', async (t) => {
-  const { script } = t.context;
+  const { workflowType } = t.context;
   {
-    const completion = await activate(t, makeStartWorkflow(script));
+    const completion = await activate(t, makeStartWorkflow(workflowType));
     compareCompletion(
       t,
       completion,
@@ -1428,9 +1454,9 @@ test('resolve activity with failure - http', async (t) => {
 });
 
 test('globalOverrides', async (t) => {
-  const { script, logs } = t.context;
+  const { workflowType, logs } = t.context;
   {
-    const completion = await activate(t, makeStartWorkflow(script));
+    const completion = await activate(t, makeStartWorkflow(workflowType));
     compareCompletion(t, completion, makeSuccess());
   }
   t.deepEqual(
@@ -1442,24 +1468,29 @@ test('globalOverrides', async (t) => {
 });
 
 test('logAndTimeout', async (t) => {
-  const { script, workflow } = t.context;
+  const { workflowType } = t.context;
   const logs: string[] = [];
+  const { startWorkflow } = makeStartWorkflowJob(workflowType);
+  const workflow = await createWorkflow(t, startWorkflow);
+  t.context.workflow = workflow;
   await workflow.injectDependency('logger', 'info', (message: string) => logs.push(message), ApplyMode.ASYNC_IGNORED);
-  await t.throwsAsync(activate(t, makeStartWorkflow(script)), { message: 'Script execution timed out.' });
+  await t.throwsAsync(activate(t, makeActivation(undefined, { startWorkflow })), {
+    message: 'Script execution timed out.',
+  });
   t.deepEqual(logs, ['logging before getting stuck']);
 });
 
 test('continueAsNewSameWorkflow', async (t) => {
-  const { script } = t.context;
+  const { workflowType } = t.context;
   {
-    const req = await activate(t, makeStartWorkflow(script));
+    const req = await activate(t, makeStartWorkflow(workflowType));
     compareCompletion(
       t,
       req,
       makeSuccess([
         {
           continueAsNewWorkflowExecution: {
-            workflowType: script,
+            workflowType,
             taskQueue: 'test',
             arguments: await defaultDataConverter.toPayloads('signal'),
           },
@@ -1470,9 +1501,9 @@ test('continueAsNewSameWorkflow', async (t) => {
 });
 
 test('not-replay patchedWorkflow', async (t) => {
-  const { logs, script } = t.context;
+  const { logs, workflowType } = t.context;
   {
-    const req = await activate(t, makeStartWorkflow(script));
+    const req = await activate(t, makeStartWorkflow(workflowType));
     compareCompletion(
       t,
       req,
@@ -1490,13 +1521,13 @@ test('not-replay patchedWorkflow', async (t) => {
 });
 
 test('replay-no-marker patchedWorkflow', async (t) => {
-  const { logs, script } = t.context;
+  const { logs, workflowType } = t.context;
   {
     const act: coresdk.workflow_activation.IWFActivation = {
       runId: 'test-runId',
       timestamp: msToTs(Date.now()),
       isReplaying: true,
-      jobs: [makeStartWorkflowJob(script)],
+      jobs: [makeStartWorkflowJob(workflowType)],
     };
     const completion = await activate(t, act);
     compareCompletion(t, completion, makeSuccess([makeStartTimerCommand({ seq: 1, startToFireTimeout: msToTs(100) })]));
@@ -1515,13 +1546,13 @@ test('replay-no-marker patchedWorkflow', async (t) => {
 });
 
 test('replay-no-marker-then-not-replay patchedWorkflow', async (t) => {
-  const { logs, script } = t.context;
+  const { logs, workflowType } = t.context;
   {
     const act: coresdk.workflow_activation.IWFActivation = {
       runId: 'test-runId',
       timestamp: msToTs(Date.now()),
       isReplaying: true,
-      jobs: [makeStartWorkflowJob(script)],
+      jobs: [makeStartWorkflowJob(workflowType)],
     };
     const completion = await activate(t, act);
     compareCompletion(t, completion, makeSuccess([makeStartTimerCommand({ seq: 1, startToFireTimeout: msToTs(100) })]));
@@ -1539,13 +1570,13 @@ test('replay-no-marker-then-not-replay patchedWorkflow', async (t) => {
 });
 
 test('replay-with-marker patchedWorkflow', async (t) => {
-  const { logs, script } = t.context;
+  const { logs, workflowType } = t.context;
   {
     const act: coresdk.workflow_activation.IWFActivation = {
       runId: 'test-runId',
       timestamp: msToTs(Date.now()),
       isReplaying: true,
-      jobs: [makeStartWorkflowJob(script), makeNotifyHasPatchJob('my-change-id')],
+      jobs: [makeStartWorkflowJob(workflowType), makeNotifyHasPatchJob('my-change-id')],
     };
     const completion = await activate(t, act);
     compareCompletion(
@@ -1565,9 +1596,9 @@ test('replay-with-marker patchedWorkflow', async (t) => {
 });
 
 test('deprecatePatchWorkflow', async (t) => {
-  const { logs, script } = t.context;
+  const { logs, workflowType } = t.context;
   {
-    const completion = await activate(t, makeStartWorkflow(script));
+    const completion = await activate(t, makeStartWorkflow(workflowType));
     compareCompletion(
       t,
       completion,
@@ -1577,4 +1608,33 @@ test('deprecatePatchWorkflow', async (t) => {
   t.deepEqual(logs, [['has change']]);
 });
 
-test.todo('no-commands-can-be-issued-once-workflow-completes');
+test('tryToContinueAfterCompletion', async (t) => {
+  const { workflowType } = t.context;
+  {
+    const completion = cleanWorkflowFailureStackTrace(await activate(t, makeStartWorkflow(workflowType)));
+    compareCompletion(
+      t,
+      completion,
+      makeSuccess([
+        makeFailWorkflowExecution(
+          'fail before continue',
+          dedent`
+          Error: fail before continue
+              at Object.execute
+        `
+        ),
+      ])
+    );
+  }
+});
+
+test('failUnlessSignaledBeforeStart', async (t) => {
+  const { workflowType } = t.context;
+  const completion = await activate(
+    t,
+    makeActivation(undefined, makeStartWorkflowJob(workflowType), {
+      signalWorkflow: { signalName: 'someShallPass' },
+    })
+  );
+  compareCompletion(t, completion, makeSuccess());
+});

--- a/packages/test/src/workflows/fail-unless-signaled-before-start.ts
+++ b/packages/test/src/workflows/fail-unless-signaled-before-start.ts
@@ -1,0 +1,18 @@
+import { Gated } from '../interfaces';
+
+export const failUnlessSignaledBeforeStart: Gated = () => {
+  let pass = false;
+  return {
+    signals: {
+      someShallPass(): void {
+        pass = true;
+      },
+    },
+
+    async execute(): Promise<void> {
+      if (!pass) {
+        throw new Error('None shall pass');
+      }
+    },
+  };
+};

--- a/packages/test/src/workflows/index.ts
+++ b/packages/test/src/workflows/index.ts
@@ -64,5 +64,7 @@ export * from './promise-race';
 export * from './tasks-and-microtasks';
 export * from './trailing-timer';
 export * from './invalid-or-failed-queries';
+export * from './try-to-continue-after-completion';
+export * from './fail-unless-signaled-before-start';
 export { interceptorExample } from './interceptor-example';
 export { internalsInterceptorExample } from './internals-interceptor-example';

--- a/packages/test/src/workflows/internals-interceptor-example.ts
+++ b/packages/test/src/workflows/internals-interceptor-example.ts
@@ -21,7 +21,7 @@ export const interceptors = (): WorkflowInterceptors => ({
   internals: [
     {
       activate(input, next) {
-        logger.log(`activate: ${input.jobIndex}`);
+        logger.log(`activate: ${input.batchIndex}`);
         return next(input);
       },
     },

--- a/packages/test/src/workflows/trailing-timer.ts
+++ b/packages/test/src/workflows/trailing-timer.ts
@@ -5,8 +5,7 @@ async function execute(): Promise<string> {
   return await Promise.race([
     sleep(1).then(() => 'first'),
     sleep(1).then(() => {
-      // This should never be executed
-      console.log('trailing timer triggered after workflow completed');
+      // This generates a command that will **not** be executed
       sleep(0);
       return 'second';
     }),

--- a/packages/test/src/workflows/try-to-continue-after-completion.ts
+++ b/packages/test/src/workflows/try-to-continue-after-completion.ts
@@ -1,0 +1,15 @@
+import { continueAsNew } from '@temporalio/workflow';
+import { Returner } from '../interfaces';
+
+/**
+ * Verifies that Workflow does not generate any more commands after it is considered complete
+ */
+export const tryToContinueAfterCompletion: Returner<void> = () => ({
+  async execute() {
+    await Promise.race([
+      // Note that continueAsNew only throws after microtasks and as a result, looses the race
+      continueAsNew<typeof tryToContinueAfterCompletion>(),
+      Promise.reject(new Error('fail before continue')),
+    ]);
+  },
+});

--- a/packages/worker/src/utils.ts
+++ b/packages/worker/src/utils.ts
@@ -3,3 +3,10 @@ export const identity = <T>(x: T): T => x;
 
 export const GiB = 1024 ** 3;
 export const MiB = 1024 ** 2;
+
+export function partition<T>(arr: T[], predicate: (x: T) => boolean): [T[], T[]] {
+  const truthy = Array<T>();
+  const falsy = Array<T>();
+  arr.forEach((v) => (predicate(v) ? truthy : falsy).push(v));
+  return [truthy, falsy];
+}

--- a/packages/worker/src/worker.ts
+++ b/packages/worker/src/worker.ts
@@ -786,20 +786,26 @@ export class Worker<T extends WorkerSpec = DefaultWorkerSpec> {
 
                   if (workflow === undefined) {
                     // Find a workflow start job in the activation jobs list
-                    // TODO: should this always be the first job in the list?
                     const maybeStartWorkflow = activation.jobs.find((j) => j.startWorkflow);
                     if (maybeStartWorkflow !== undefined) {
-                      const attrs = maybeStartWorkflow.startWorkflow;
-                      if (!(attrs && attrs.workflowId && attrs.workflowType && attrs.randomnessSeed)) {
+                      const startWorkflow = maybeStartWorkflow.startWorkflow;
+                      if (
+                        !(
+                          startWorkflow &&
+                          startWorkflow.workflowId &&
+                          startWorkflow.workflowType &&
+                          startWorkflow.randomnessSeed
+                        )
+                      ) {
                         throw new TypeError(
                           `Expected StartWorkflow with workflowId, workflowType and randomnessSeed, got ${JSON.stringify(
                             maybeStartWorkflow
                           )}`
                         );
                       }
-                      const { workflowId, randomnessSeed, workflowType } = attrs;
+                      const { workflowId, randomnessSeed, workflowType } = startWorkflow;
                       this.log.debug('Creating workflow', {
-                        workflowId: attrs.workflowId,
+                        workflowId,
                         runId: activation.runId,
                       });
                       this.numRunningWorkflowInstancesSubject.next(this.numRunningWorkflowInstancesSubject.value + 1);
@@ -819,6 +825,7 @@ export class Worker<T extends WorkerSpec = DefaultWorkerSpec> {
                           },
                           this.options.interceptors?.workflowModules ?? [],
                           randomnessSeed,
+                          startWorkflow,
                           this.options.isolateExecutionTimeoutMs
                         );
                       });

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -76,7 +76,7 @@ export {
   TerminatedFailure,
   TimeoutFailure,
 } from '@temporalio/common';
-export { ActivationJobResult, ChildWorkflowOptions, ChildWorkflowCancellationType, WorkflowInfo } from './interfaces';
+export { ChildWorkflowOptions, ChildWorkflowCancellationType, WorkflowInfo } from './interfaces';
 export * from './errors';
 export * from './workflow';
 export * from './interceptors';

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1,6 +1,5 @@
 import { coresdk } from '@temporalio/proto/lib/coresdk';
 import { WorkflowOptions } from '@temporalio/common';
-import { ExternalCall } from './dependencies';
 
 /**
  * Workflow execution information
@@ -103,8 +102,3 @@ export type RequiredChildWorkflowOptions = Required<
 >;
 
 export type ChildWorkflowOptionsWithDefaults = ChildWorkflowOptions & RequiredChildWorkflowOptions;
-
-export interface ActivationJobResult {
-  pendingExternalCalls: ExternalCall[];
-  processed: boolean;
-}

--- a/packages/workflow/src/worker-interface.ts
+++ b/packages/workflow/src/worker-interface.ts
@@ -4,10 +4,19 @@
  * @module
  */
 import ivm from 'isolated-vm';
-import { IllegalStateError, msToTs, tsToMs, composeInterceptors } from '@temporalio/common';
+import {
+  IllegalStateError,
+  msToTs,
+  tsToMs,
+  composeInterceptors,
+  Workflow,
+  ApplicationFailure,
+  errorMessage,
+  arrayFromPayloadsSync,
+} from '@temporalio/common';
 import { coresdk } from '@temporalio/proto/lib/coresdk';
-import { WorkflowInfo, ActivationJobResult } from './interfaces';
-import { consumeCompletion, state } from './internals';
+import { WorkflowInfo } from './interfaces';
+import { consumeCompletion, handleWorkflowFailure, state } from './internals';
 import { alea } from './alea';
 import { IsolateExtension, HookManager } from './promise-hooks';
 import { DeterminismViolationError } from './errors';
@@ -51,7 +60,7 @@ export function overrideGlobals(): void {
       resolve: () => cb(...args),
       reject: () => undefined /* ignore cancellation */,
     });
-    state.commands.push({
+    state.pushCommand({
       startTimer: {
         seq,
         startToFireTimeout: msToTs(ms),
@@ -63,7 +72,7 @@ export function overrideGlobals(): void {
   global.clearTimeout = function (handle: number): void {
     state.nextSeqs.timer++;
     state.completions.timer.delete(handle);
-    state.commands.push({
+    state.pushCommand({
       cancelTimer: {
         seq: handle,
       },
@@ -114,12 +123,13 @@ export function mockBrowserDocumentForWebpack(): MockDocument {
   };
 }
 
-export function initRuntime(
+export async function initRuntime(
   info: WorkflowInfo,
   interceptorModules: string[],
   randomnessSeed: number[],
-  isolateExtension: IsolateExtension
-): void {
+  isolateExtension: IsolateExtension,
+  encodedStartWorkflow: Uint8Array
+): Promise<void> {
   // Globals are overridden while building the isolate before loading user code.
   // For some reason the `WeakRef` mock is not restored properly when creating an isolate from snapshot in node 14 (at least on ubuntu), override again.
   (globalThis as any).WeakRef = function () {
@@ -146,48 +156,83 @@ export function initRuntime(
       state.interceptors.internals.push(...(interceptors.internals ?? []));
     }
   }
+  const { headers, arguments: args } = coresdk.workflow_activation.StartWorkflow.decodeDelimited(encodedStartWorkflow);
+
+  const create = composeInterceptors(state.interceptors.inbound, 'create', async ({ args }) => {
+    let mod: Workflow;
+    try {
+      mod = req(undefined, info.workflowType);
+      if (typeof mod !== 'function') {
+        throw new TypeError(`'${info.workflowType}' is not a function`);
+      }
+    } catch (err) {
+      const failure = ApplicationFailure.nonRetryable(errorMessage(err), 'ReferenceError');
+      failure.stack = failure.stack?.split('\n')[0];
+      throw failure;
+    }
+    return mod(...args);
+  });
+
+  state.workflow =
+    (await create({
+      headers: new Map(Object.entries(headers ?? {})),
+      args: arrayFromPayloadsSync(state.dataConverter, args),
+    }).catch(handleWorkflowFailure)) ?? undefined;
 }
 
 /**
- * Run a single activation job.
- * @param jobIndex index of job to process in the activation's job array.
- * @returns a boolean indicating whether the job was processed or ignored
+ * Run a chunk of activation jobs
+ * @returns a boolean indicating whether job was processed or ignored
  */
-export async function activate(encodedActivation: Uint8Array, jobIndex: number): Promise<ActivationJobResult> {
-  const intercept = composeInterceptors(state.interceptors.internals, 'activate', async ({ activation, jobIndex }) => {
-    const job = activation.jobs?.[jobIndex] as coresdk.workflow_activation.WFActivationJob;
-    // We only accept time not progressing when processing a query
-    if (!(job.variant === 'queryWorkflow' && activation.timestamp === null)) {
-      state.now = tsToMs(activation.timestamp);
+export async function activate(encodedActivation: Uint8Array, batchIndex: number): Promise<ExternalCall[]> {
+  const intercept = composeInterceptors(
+    state.interceptors.internals,
+    'activate',
+    async ({ activation, batchIndex }) => {
+      if (batchIndex === 0) {
+        if (state.info === undefined) {
+          throw new IllegalStateError('Workflow has not been initialized');
+        }
+        if (!activation.jobs) {
+          throw new TypeError('Got activation with no jobs');
+        }
+        if (activation.timestamp !== null) {
+          // timestamp will not be updated for activation that contain only queries
+          state.now = tsToMs(activation.timestamp);
+        }
+        state.info.isReplaying = activation.isReplaying ?? false;
+      }
+
+      // Cast from the interface to the class which has the `variant` attribute.
+      // This is safe because we just decoded this activation from a buffer.
+      const jobs = activation.jobs as coresdk.workflow_activation.WFActivationJob[];
+
+      await Promise.all(
+        jobs.map(async (job) => {
+          if (job.variant === undefined) {
+            throw new TypeError('Expected job.variant to be defined');
+          }
+          const variant = job[job.variant];
+          if (!variant) {
+            throw new TypeError(`Expected job.${job.variant} to be set`);
+          }
+          // The only job that can be executed on a completed workflow is a query.
+          // We might get other jobs after completion for instance when a single
+          // activation contains multiple jobs and the first one completes the workflow.
+          if (state.completed && job.variant !== 'queryWorkflow') {
+            return;
+          }
+          await state.activator[job.variant](variant as any /* TODO: TS is struggling with `true` and `{}` */);
+        })
+      );
     }
-    if (state.info === undefined) {
-      throw new IllegalStateError('Workflow has not been initialized');
-    }
-    state.info.isReplaying = activation.isReplaying ?? false;
-    if (job.variant === undefined) {
-      throw new TypeError('Expected job.variant to be defined');
-    }
-    const variant = job[job.variant];
-    if (!variant) {
-      throw new TypeError(`Expected job.${job.variant} to be set`);
-    }
-    // The only job that can be executed on a completed workflow is a query.
-    // We might get other jobs after completion for instance when a single
-    // activation contains multiple jobs and the first one completes the workflow.
-    if (state.completed && job.variant !== 'queryWorkflow') {
-      return false;
-    }
-    await state.activator[job.variant](variant as any /* TODO: TS is struggling with `true` and `{}` */);
-    return true;
+  );
+  await intercept({
+    activation: coresdk.workflow_activation.WFActivation.decodeDelimited(encodedActivation),
+    batchIndex,
   });
 
-  return {
-    processed: await intercept({
-      activation: coresdk.workflow_activation.WFActivation.decodeDelimited(encodedActivation),
-      jobIndex,
-    }),
-    pendingExternalCalls: state.getAndResetPendingExternalCalls(),
-  };
+  return state.getAndResetPendingExternalCalls();
 }
 
 type ActivationConclusion =


### PR DESCRIPTION
BREAKING CHANGE: Workflow histories generated by old versions of the SDK
might break with non-determinism errors.
WorkflowInboundCallsInterceptor now has a `create` method to intercept
Workflow creation, the `WorkflowInput` interface was renamed
`WorkflowExecuteInput`.

Closes #202 