### PR TITLE
feat(client): Follow Workflow execution chain

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,8 +23,7 @@ See [sdk-structure.md](./docs/sdk-structure.md)
   ```
 - Initialize the Core SDK submodule:
   ```sh
-  git submodule init
-  git submodule update
+  git submodule update --init --recursive
   ```
 - Install the dependencies:
   ```sh

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -41,7 +41,9 @@ export class WorkflowExecutionCancelledError extends Error {
 }
 
 /**
- * Thrown by client when waiting on Workflow execution result if Workflow continues as new
+ * Thrown by client when waiting on Workflow execution result if Workflow continues as new.
+ *
+ * Only thrown if asked not to follow the chain of execution (see {@link WorkflowOptions.followRuns}).
  */
 export class WorkflowExecutionContinuedAsNewError extends Error {
   public readonly name: string = 'WorkflowExecutionContinuedAsNewError';

--- a/packages/client/src/workflow-client.ts
+++ b/packages/client/src/workflow-client.ts
@@ -147,6 +147,14 @@ export interface WorkflowClientOptions {
    * @default QUERY_REJECT_CONDITION_UNSPECIFIED which means that closed and failed workflows are still queryable
    */
   queryRejectCondition?: temporal.api.enums.v1.QueryRejectCondition;
+
+  /**
+   * Apply default options for starting new Workflows.
+   *
+   * These defaults are **shallowly** merged with options provided to methods that start Workflows
+   * e.g. {@link WorkflowHandle.start}.
+   */
+  workflowDefaults?: Partial<WorkflowOptions>;
 }
 
 export type WorkflowClientOptionsWithDefaults = Required<WorkflowClientOptions>;
@@ -159,7 +167,39 @@ export function defaultWorkflowClientOptions(): WorkflowClientOptionsWithDefault
     interceptors: {},
     namespace: 'default',
     queryRejectCondition: temporal.api.enums.v1.QueryRejectCondition.QUERY_REJECT_CONDITION_UNSPECIFIED,
+    workflowDefaults: {},
   };
+}
+
+function assertRequiredWorkflowOptions(opts: Partial<WorkflowOptions>): asserts opts is WorkflowOptions {
+  if (!opts.taskQueue) {
+    throw new TypeError('Missing WorkflowOptions.taskQueue');
+  }
+}
+
+/**
+ * Same as the protocol's {@link WorkflowExecution} but `workflowId` is required.
+ *
+ * NOTE: Does not accept nulls.
+ */
+export interface ValidWorkflowExecution {
+  workflowId: string;
+  runId?: string;
+}
+
+/**
+ * Options for getting a result of a Workflow execution.
+ */
+export interface WorkflowResultOptions {
+  /**
+   * If set to true, instructs the client to follow the chain of execution before returning a Workflow's result.
+   *
+   * Workflow execution is chained if the Workflow has a cron schedule or continues-as-new or configured to retry
+   * after failure or timeout.
+   *
+   * @default true
+   */
+  followRuns: boolean;
 }
 
 /**
@@ -175,8 +215,14 @@ export class WorkflowClient {
   /**
    * Start a new Workflow execution. Resolves with the execution `runId`.
    */
-  public async start<T extends Workflow>(opts: WorkflowOptions, name: string, ...args: Parameters<T>): Promise<string> {
-    const compiledOptions = compileWorkflowOptions(addDefaults(opts));
+  public async start<T extends Workflow>(
+    opts: Partial<WorkflowOptions>,
+    name: string,
+    ...args: Parameters<T>
+  ): Promise<string> {
+    const mergedOptions = { ...this.options.workflowDefaults, ...opts };
+    assertRequiredWorkflowOptions(mergedOptions);
+    const compiledOptions = compileWorkflowOptions(addDefaults(mergedOptions));
 
     const interceptors = (this.options.interceptors.calls ?? []).map((ctor) =>
       ctor({ workflowId: compiledOptions.workflowId })
@@ -198,26 +244,29 @@ export class WorkflowClient {
    * Starts a new Workflow execution and awaits its completion
    */
   public async execute<T extends Workflow>(
-    opts: WorkflowOptions,
+    opts: Partial<WorkflowOptions>,
     name: string,
     ...args: Parameters<T>
-  ): // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  WorkflowResultType<T> {
+  ): Promise<WorkflowResultType<T>> {
     const workflowId = opts.workflowId ?? uuid4();
     const runId = await this.start({ ...opts, workflowId }, name, ...args);
-    return this.result(workflowId, runId);
+    return this.result({ workflowId, runId });
   }
 
   /**
-   * Gets the result of a Workflow execution
+   * Gets the result of a Workflow execution.
+   *
+   * Follows the chain of execution in case Workflow continues as new, or has a cron schedule or retry policy.
    */
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  public async result<T extends Workflow>(workflowId: string, runId?: string): ReturnType<T['execute']> {
+  public async result<T extends Workflow>(
+    { workflowId, runId }: ValidWorkflowExecution,
+    opts?: WorkflowResultOptions
+  ): Promise<WorkflowResultType<T>> {
+    const followRuns = opts?.followRuns ?? true;
+    const execution: temporal.api.common.v1.IWorkflowExecution = { workflowId, runId };
     const req: GetWorkflowExecutionHistoryRequest = {
       namespace: this.options.namespace,
-      execution: { workflowId, runId },
+      execution,
       skipArchival: true,
       waitNewEvent: true,
       historyEventFilterType: temporal.api.enums.v1.HistoryEventFilterType.HISTORY_EVENT_FILTER_TYPE_CLOSE_EVENT,
@@ -241,51 +290,73 @@ export class WorkflowClient {
         throw new Error(`Expected at most 1 close event(s), got: ${events.length}`);
       }
       ev = events[0];
-      break;
-    }
 
-    if (ev.workflowExecutionCompletedEventAttributes) {
-      // Note that we can only return one value from our workflow function in JS.
-      // Ignore any other payloads in result
-      const [result] = await arrayFromPayloads(
-        this.options.dataConverter,
-        ev.workflowExecutionCompletedEventAttributes.result?.payloads
-      );
-      return result as any;
-    } else if (ev.workflowExecutionFailedEventAttributes) {
-      const { failure } = ev.workflowExecutionFailedEventAttributes;
-      throw new errors.WorkflowExecutionFailedError(
-        'Workflow execution failed',
-        await optionalFailureToOptionalError(failure, this.options.dataConverter)
-      );
-    } else if (ev.workflowExecutionCanceledEventAttributes) {
-      throw new errors.WorkflowExecutionCancelledError(
-        'Workflow execution cancelled',
-        await arrayFromPayloads(
+      if (ev.workflowExecutionCompletedEventAttributes) {
+        if (followRuns && ev.workflowExecutionCompletedEventAttributes.newExecutionRunId) {
+          execution.runId = ev.workflowExecutionCompletedEventAttributes.newExecutionRunId;
+          req.nextPageToken = undefined;
+          continue;
+        }
+        // Note that we can only return one value from our workflow function in JS.
+        // Ignore any other payloads in result
+        const [result] = await arrayFromPayloads(
           this.options.dataConverter,
-          ev.workflowExecutionCanceledEventAttributes.details?.payloads
-        )
-      );
-    } else if (ev.workflowExecutionTerminatedEventAttributes) {
-      throw new errors.WorkflowExecutionTerminatedError(
-        ev.workflowExecutionTerminatedEventAttributes.reason || 'Workflow execution terminated',
-        await arrayFromPayloads(
-          this.options.dataConverter,
-          ev.workflowExecutionTerminatedEventAttributes.details?.payloads
-        ),
-        ev.workflowExecutionTerminatedEventAttributes.identity ?? undefined
-      );
-    } else if (ev.workflowExecutionTimedOutEventAttributes) {
-      throw new errors.WorkflowExecutionTimedOutError(
-        'Workflow execution timed out',
-        ev.workflowExecutionTimedOutEventAttributes.retryState || 0
-      );
-    } else if (ev.workflowExecutionContinuedAsNewEventAttributes) {
-      const { newExecutionRunId } = ev.workflowExecutionContinuedAsNewEventAttributes;
-      if (!newExecutionRunId) {
-        throw new Error('Expected service to return newExecutionRunId for WorkflowExecutionContinuedAsNewEvent');
+          ev.workflowExecutionCompletedEventAttributes.result?.payloads
+        );
+        return result as any;
+      } else if (ev.workflowExecutionFailedEventAttributes) {
+        if (followRuns && ev.workflowExecutionFailedEventAttributes.newExecutionRunId) {
+          execution.runId = ev.workflowExecutionFailedEventAttributes.newExecutionRunId;
+          req.nextPageToken = undefined;
+          continue;
+        }
+        const { failure } = ev.workflowExecutionFailedEventAttributes;
+        throw new errors.WorkflowExecutionFailedError(
+          'Workflow execution failed',
+          await optionalFailureToOptionalError(failure, this.options.dataConverter)
+        );
+      } else if (ev.workflowExecutionCanceledEventAttributes) {
+        throw new errors.WorkflowExecutionCancelledError(
+          'Workflow execution cancelled',
+          await arrayFromPayloads(
+            this.options.dataConverter,
+            ev.workflowExecutionCanceledEventAttributes.details?.payloads
+          )
+        );
+      } else if (ev.workflowExecutionTerminatedEventAttributes) {
+        throw new errors.WorkflowExecutionTerminatedError(
+          ev.workflowExecutionTerminatedEventAttributes.reason || 'Workflow execution terminated',
+          await arrayFromPayloads(
+            this.options.dataConverter,
+            ev.workflowExecutionTerminatedEventAttributes.details?.payloads
+          ),
+          ev.workflowExecutionTerminatedEventAttributes.identity ?? undefined
+        );
+      } else if (ev.workflowExecutionTimedOutEventAttributes) {
+        if (ev.workflowExecutionTimedOutEventAttributes.newExecutionRunId) {
+          execution.runId = ev.workflowExecutionTimedOutEventAttributes.newExecutionRunId;
+          req.nextPageToken = undefined;
+          continue;
+        }
+        throw new errors.WorkflowExecutionTimedOutError(
+          'Workflow execution timed out',
+          ev.workflowExecutionTimedOutEventAttributes.retryState || 0
+        );
+      } else if (ev.workflowExecutionContinuedAsNewEventAttributes) {
+        const { newExecutionRunId } = ev.workflowExecutionContinuedAsNewEventAttributes;
+        if (!newExecutionRunId) {
+          throw new TypeError('Expected service to return newExecutionRunId for WorkflowExecutionContinuedAsNewEvent');
+        }
+        if (!followRuns) {
+          throw new errors.WorkflowExecutionContinuedAsNewError(
+            'Workflow execution continued as new',
+            newExecutionRunId
+          );
+        }
+        execution.runId = newExecutionRunId;
+        req.nextPageToken = undefined;
+        continue;
       }
-      throw new errors.WorkflowExecutionContinuedAsNewError('Workflow execution continued as new', newExecutionRunId);
     }
   }
 
@@ -445,7 +516,7 @@ export class WorkflowClient {
    * @param name workflow type name (the exported function name in the Node.js SDK)
    * @param options used to start the Workflow
    */
-  public createWorkflowHandle<T extends Workflow>(name: string, options: WorkflowOptions): WorkflowHandle<T>;
+  public createWorkflowHandle<T extends Workflow>(name: string, options?: Partial<WorkflowOptions>): WorkflowHandle<T>;
 
   /**
    * Create a {@link WorkflowHandle} for starting a new Workflow execution
@@ -453,45 +524,35 @@ export class WorkflowClient {
    * @param func an exported function
    * @param options used to start the Workflow
    */
-  public createWorkflowHandle<T extends Workflow>(func: T, options: WorkflowOptions): WorkflowHandle<T>;
+  public createWorkflowHandle<T extends Workflow>(func: T, options?: Partial<WorkflowOptions>): WorkflowHandle<T>;
 
   /**
    * Create a {@link WorkflowHandle} for an existing Workflow execution
    */
-  public createWorkflowHandle<T extends Workflow>(workflowId: string, runId?: string): WorkflowHandle<T>;
+  public createWorkflowHandle<T extends Workflow>(execution: ValidWorkflowExecution): WorkflowHandle<T>;
 
   public createWorkflowHandle<T extends Workflow>(
-    nameOrWorkflowIdOrFunc: string | T,
-    optionsOrRunId?: WorkflowOptions | string
+    executionOrNameOrFunc: string | T | ValidWorkflowExecution,
+    options?: Partial<WorkflowOptions>
   ): WorkflowHandle<T> {
-    const nameOrWorkflowId =
-      typeof nameOrWorkflowIdOrFunc === 'string'
-        ? nameOrWorkflowIdOrFunc
-        : typeof nameOrWorkflowIdOrFunc === 'function'
-        ? nameOrWorkflowIdOrFunc.name
+    const workflowExecution =
+      typeof executionOrNameOrFunc === 'object' && executionOrNameOrFunc.workflowId ? executionOrNameOrFunc : undefined;
+    if (workflowExecution !== undefined) {
+      return this.connectToExistingWorkflow(workflowExecution);
+    }
+    const workflowType =
+      typeof executionOrNameOrFunc === 'string'
+        ? executionOrNameOrFunc
+        : typeof executionOrNameOrFunc === 'function'
+        ? executionOrNameOrFunc.name
         : undefined;
 
-    if (typeof nameOrWorkflowId !== 'string') {
+    if (typeof workflowType !== 'string') {
       throw new TypeError(
-        `Invalid argument: ${nameOrWorkflowIdOrFunc}, expected a Workflow function or a string with the Workflow name or Workflow ID`
+        `Invalid argument: ${executionOrNameOrFunc}, expected one of: Workflow function, a string with the Workflow type name, or WorkflowExecution`
       );
     }
-    if (optionsOrRunId === undefined) {
-      const workflowId = nameOrWorkflowId;
-      return this.connectToExistingWorkflow(workflowId);
-    } else if (typeof optionsOrRunId === 'string') {
-      const workflowId = nameOrWorkflowId;
-      const runId = optionsOrRunId;
-      return this.connectToExistingWorkflow(workflowId, runId);
-    } else if (typeof optionsOrRunId === 'object') {
-      const name = nameOrWorkflowId;
-      const options = optionsOrRunId;
-      return this.createNewWorkflow(name, options);
-    } else {
-      throw new TypeError(
-        `Invalid argument: ${optionsOrRunId}, expected either runId (string) or options (WorkflowOptions)`
-      );
-    }
+    return this.createNewWorkflow(workflowType, options);
   }
 
   /**
@@ -502,24 +563,30 @@ export class WorkflowClient {
     runId: string | undefined,
     interceptors: WorkflowClientCallsInterceptor[],
     start: WorkflowHandle<T>['start'],
-    signalWithStart: WorkflowHandle<T>['signalWithStart']
+    signalWithStart: WorkflowHandle<T>['signalWithStart'],
+    resultOptions: WorkflowResultOptions
   ): WorkflowHandle<T> {
     const namespace = this.options.namespace;
+    let startPromise: Promise<string> | undefined = undefined;
 
     const workflow = {
       client: this,
       workflowId,
-      execute(...args: Parameters<T>): WorkflowResultType<T> {
-        // TODO: fix the type here
-        return this.start(...args).then(() => this.result()) as any;
+      async execute(...args: Parameters<T>): Promise<WorkflowResultType<T>> {
+        await this.start(...args);
+        return await this.result();
       },
       async start(...args: Parameters<T>) {
+        if (startPromise !== undefined) {
+          throw new IllegalStateError('Workflow execution already started');
+        }
+        startPromise = start(...args);
         // Override runId in outer scope
-        runId = await start(...args);
+        runId = await startPromise;
         return runId;
       },
-      result(): WorkflowResultType<T> {
-        return this.client.result(workflowId, runId);
+      async result(): Promise<WorkflowResultType<T>> {
+        return this.client.result({ workflowId, runId }, resultOptions);
       },
       async terminate(reason?: string) {
         const next = this.client._terminateWorkflowHandler.bind(this.client);
@@ -593,11 +660,14 @@ export class WorkflowClient {
   /**
    * Creates a Workflow handle for existing Workflow using `workflowId` and optional `runId`
    */
-  protected connectToExistingWorkflow<T extends Workflow>(workflowId: string, runId?: string): WorkflowHandle<T> {
+  protected connectToExistingWorkflow<T extends Workflow>({
+    workflowId,
+    runId,
+  }: ValidWorkflowExecution): WorkflowHandle<T> {
     const interceptors = (this.options.interceptors.calls ?? []).map((ctor) => ctor({ workflowId, runId }));
 
     const startCallback = () => {
-      throw new IllegalStateError('Workflow created with no WorkflowOptions cannot be started');
+      throw new IllegalStateError('WorkflowHandle created with no WorkflowOptions cannot be started');
     };
     return this._createWorkflowHandle(
       workflowId,
@@ -605,15 +675,18 @@ export class WorkflowClient {
       interceptors,
       startCallback,
       // Requires cast because workflow signals are optional which complicate the type
-      startCallback as any
+      startCallback as any,
+      { followRuns: this.options.workflowDefaults.followRuns ?? true }
     );
   }
 
   /**
    * Creates a Workflow handle for new Workflow execution
    */
-  protected createNewWorkflow<T extends Workflow>(name: string, options: WorkflowOptions): WorkflowHandle<T> {
-    const compiledOptions = compileWorkflowOptions(addDefaults(options));
+  protected createNewWorkflow<T extends Workflow>(name: string, options?: Partial<WorkflowOptions>): WorkflowHandle<T> {
+    const mergedOptions = { ...this.options.workflowDefaults, ...options };
+    assertRequiredWorkflowOptions(mergedOptions);
+    const compiledOptions = compileWorkflowOptions(addDefaults(mergedOptions));
 
     const interceptors = (this.options.interceptors.calls ?? []).map((ctor) =>
       ctor({ workflowId: compiledOptions.workflowId })
@@ -653,7 +726,8 @@ export class WorkflowClient {
       interceptors,
       start,
       // Requires cast because workflow signals are optional which complicate the type
-      signalWithStart as any
+      signalWithStart as any,
+      { followRuns: mergedOptions.followRuns ?? true }
     );
   }
 }

--- a/packages/client/src/workflow-options.ts
+++ b/packages/client/src/workflow-options.ts
@@ -1,18 +1,32 @@
 import { v4 as uuid4 } from 'uuid';
 import {
   WorkflowOptions as BaseWorkflowOptions,
-  WorkflowOptionsWithDefaults,
+  WorkflowOptionsWithDefaults as BaseWorkflowOptionsWithDefaults,
 } from '@temporalio/common/lib/workflow-options';
 import * as iface from '@temporalio/proto';
 
-export {
-  WorkflowOptionsWithDefaults,
-  CompiledWorkflowOptions,
-  compileWorkflowOptions,
-} from '@temporalio/common/lib/workflow-options';
+export { CompiledWorkflowOptions, compileWorkflowOptions } from '@temporalio/common/lib/workflow-options';
 
 export interface WorkflowOptions extends BaseWorkflowOptions {
+  /**
+   * Task queue to use for Workflow tasks. It should match a task queue specified when creating a
+   * `Worker` that hosts the Workflow code.
+   */
   taskQueue: string;
+
+  followRuns?: boolean;
+}
+
+export interface WorkflowOptionsWithDefaults extends BaseWorkflowOptionsWithDefaults {
+  /**
+   * If set to true, instructs the client to follow the chain of execution before returning a Workflow's result.
+   *
+   * Workflow execution is chained if the Workflow has a cron schedule or continues-as-new or configured to retry
+   * after failure or timeout.
+   *
+   * @default true
+   */
+  followRuns: boolean;
 }
 
 /**
@@ -20,7 +34,8 @@ export interface WorkflowOptions extends BaseWorkflowOptions {
  */
 export function addDefaults(opts: WorkflowOptions): WorkflowOptionsWithDefaults {
   return {
-    workflowId: uuid4(),
+    followRuns: true,
+    workflowId: opts.workflowId ?? uuid4(),
     workflowIdReusePolicy:
       iface.temporal.api.enums.v1.WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
     ...opts,

--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -17,13 +17,15 @@ export interface WorkflowHandlers {
  */
 export type Workflow = (...args: any[]) => WorkflowHandlers;
 
-/** Get the execute handler from Workflow interface `W` */
+/** Get the execute handler from Workflow type `W` */
 export type WorkflowExecuteHandler<W extends Workflow> = ReturnType<W>['execute'];
-/** Get the return type of the execute handler from Workflow interface `W` */
-export type WorkflowResultType<W extends Workflow> = ReturnType<WorkflowExecuteHandler<W>>;
-/** Get the signal handler definitions from Workflow interface `W` */
+/** Get the "unwrapped" return type (without Promise) of the execute handler from Workflow type `W` */
+export type WorkflowResultType<W extends Workflow> = ReturnType<WorkflowExecuteHandler<W>> extends Promise<infer R>
+  ? R
+  : never;
+/** Get the signal handler definitions from Workflow type `W` */
 export type WorkflowSignalHandlers<W extends Workflow> = ReturnType<W>['signals'];
-/** Get the query handler definitions from Workflow interface `W` */
+/** Get the query handler definitions from Workflow type `W` */
 export type WorkflowQueryHandlers<W extends Workflow> = ReturnType<W>['queries'];
 
 /**

--- a/packages/common/src/workflow-handle.ts
+++ b/packages/common/src/workflow-handle.ts
@@ -19,7 +19,7 @@ export interface BaseWorkflowHandle<T extends Workflow> {
   /**
    * Start the Workflow with arguments, returns a Promise that resolves when the Workflow execution completes
    */
-  execute(...args: Parameters<T>): WorkflowResultType<T>;
+  execute(...args: Parameters<T>): Promise<WorkflowResultType<T>>;
 
   /**
    * Start the Workflow with arguments, returns a Promise that resolves with the execution runId
@@ -29,7 +29,7 @@ export interface BaseWorkflowHandle<T extends Workflow> {
   /**
    * Promise that resolves when Workflow execution completes
    */
-  result(): WorkflowResultType<T>;
+  result(): Promise<WorkflowResultType<T>>;
 
   /**
    * A mapping of the different signals defined by Workflow interface `T` to callable functions.

--- a/packages/common/src/workflow-options.ts
+++ b/packages/common/src/workflow-options.ts
@@ -26,8 +26,8 @@ export interface BaseWorkflowOptions {
   workflowIdReusePolicy?: WorkflowIdReusePolicy;
 
   /**
-   * Task queue to use for workflow tasks. It should match a task queue specified when creating a
-   * `Worker` that hosts the workflow code.
+   * Task queue to use for Workflow tasks. It should match a task queue specified when creating a
+   * `Worker` that hosts the Workflow code.
    */
   taskQueue?: string;
 

--- a/packages/core-bridge/Cargo.lock
+++ b/packages/core-bridge/Cargo.lock
@@ -879,6 +879,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-prometheus"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee9c06c1366665e7d4dba6540a42ea48900a9c92dc5b963f3ae05fbba76dc63"
+dependencies = [
+ "opentelemetry",
+ "prometheus",
+ "protobuf",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,6 +999,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5986aa8d62380092d2f50f8b1cdba9cb9b6731ffd4b25b51fd126b6c3e05b99c"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror",
+]
+
+[[package]]
 name = "prost"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1037,6 +1063,12 @@ dependencies = [
  "bytes",
  "prost",
 ]
+
+[[package]]
+name = "protobuf"
+version = "2.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23129d50f2c9355ced935fce8a08bd706ee2e7ce2b3b33bf61dace0e379ac63a"
 
 [[package]]
 name = "quote"
@@ -1416,6 +1448,7 @@ dependencies = [
  "derive_more",
  "futures",
  "futures-retry",
+ "http",
  "itertools",
  "lazy_static",
  "log",
@@ -1423,7 +1456,9 @@ dependencies = [
  "once_cell",
  "opentelemetry",
  "opentelemetry-otlp",
+ "opentelemetry-prometheus",
  "parking_lot",
+ "prometheus",
  "prost",
  "prost-types",
  "rand",
@@ -1436,6 +1471,7 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tonic-build",
+ "tower",
  "tracing",
  "tracing-futures",
  "tracing-opentelemetry",

--- a/packages/test/src/interfaces/index.ts
+++ b/packages/test/src/interfaces/index.ts
@@ -84,7 +84,10 @@ export type CancellableHTTPRequest = (url: string) => {
   };
 };
 
-export type ContinueAsNewFromMainAndSignal = (continueFrom?: 'execute' | 'signal' | 'none') => {
+export type ContinueAsNewFromMainAndSignal = (
+  continueFrom?: 'execute' | 'signal' | 'none',
+  continueTo?: 'execute' | 'signal' | 'none'
+) => {
   execute(): Promise<void>;
   signals: {
     continueAsNew(): void;

--- a/packages/test/src/workflows/continue-as-new-same-workflow.ts
+++ b/packages/test/src/workflows/continue-as-new-same-workflow.ts
@@ -5,13 +5,16 @@
 import { continueAsNew, CancellationScope } from '@temporalio/workflow';
 import { ContinueAsNewFromMainAndSignal } from '../interfaces';
 
-export const continueAsNewSameWorkflow: ContinueAsNewFromMainAndSignal = (continueFrom = 'execute') => ({
+export const continueAsNewSameWorkflow: ContinueAsNewFromMainAndSignal = (
+  continueFrom = 'execute',
+  continueTo = 'signal'
+) => ({
   async execute(): Promise<void> {
     if (continueFrom === 'none') {
       return;
     }
     if (continueFrom === 'execute') {
-      await continueAsNew<ContinueAsNewFromMainAndSignal>('signal');
+      await continueAsNew<ContinueAsNewFromMainAndSignal>(continueTo);
     }
     await CancellationScope.current().cancelRequested;
   },

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -34,7 +34,7 @@ registerSleepImplementation(sleep);
 export function addDefaultWorkflowOptions(opts: ChildWorkflowOptions): ChildWorkflowOptionsWithDefaults {
   return {
     taskQueue: workflowInfo().taskQueue,
-    workflowId: uuid4(),
+    workflowId: opts.workflowId ?? uuid4(),
     workflowIdReusePolicy: coresdk.common.WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
     cancellationType: ChildWorkflowCancellationType.WAIT_CANCELLATION_COMPLETED,
     ...opts,
@@ -506,13 +506,11 @@ export function createChildWorkflowHandle<T extends Workflow>(
       });
       return await started;
     },
-    async execute(...args: Parameters<T>): // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    WorkflowResultType<T> {
+    async execute(...args: Parameters<T>): Promise<WorkflowResultType<T>> {
       await this.start(...args);
-      return this.result();
+      return await this.result();
     },
-    result(): WorkflowResultType<T> {
+    result(): Promise<WorkflowResultType<T>> {
       if (completed === undefined) {
         throw new IllegalStateError('Child Workflow was not started');
       }


### PR DESCRIPTION
BREAKING CHANGE: `WorkflowClient.result()` and
`WorkflowClient.createWorkflowStub()` override for attaching to an
existing Workflow now takes an object with `workflowId` and optional
`runId` instead of 2 strings.

`workflowDefaults` added to `WorkflowClientOptions`, if provided they
will be merged with per-method and per-handle options.

`WorkflowOptions` takes a `followRuns` boolean option which defaults to
`true`, it determines whether or not the client will follow the Workflow
execution chain when getting a Workflow's result.

Closes #222 