### PR TITLE
chore: Fix TS project references

### DIFF
--- a/.buildkite/docker/build-and-run-load.sh
+++ b/.buildkite/docker/build-and-run-load.sh
@@ -6,12 +6,8 @@ node --version
 npm --version
 
 npm set progress=false
-export SKIP_DOCS_INSTALL=true
 export TEMPORAL_TESTING_SERVER_URL="temporal:7233"
 
 npm ci
-# Try rebuilding once if it fails
-# TODO: Figure out whatever problem causes "common" package to not get compiled when it should
-npm run build || npm run build
-
+npm run build
 npm run ci-load

--- a/package-lock.json
+++ b/package-lock.json
@@ -11963,6 +11963,7 @@
       }
     },
     "packages/activity": {
+      "name": "@temporalio/activity",
       "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
@@ -11970,6 +11971,7 @@
       }
     },
     "packages/client": {
+      "name": "@temporalio/client",
       "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
@@ -11990,6 +11992,7 @@
       }
     },
     "packages/common": {
+      "name": "@temporalio/common",
       "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
@@ -11998,6 +12001,7 @@
       }
     },
     "packages/core-bridge": {
+      "name": "@temporalio/core-bridge",
       "version": "0.4.0",
       "hasInstallScript": true,
       "license": "MIT",
@@ -12007,6 +12011,7 @@
       }
     },
     "packages/create-project": {
+      "name": "@temporalio/create",
       "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
@@ -12018,6 +12023,7 @@
       }
     },
     "packages/interceptors-opentelemetry": {
+      "name": "@temporalio/interceptors-opentelemetry",
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
@@ -12031,6 +12037,7 @@
       }
     },
     "packages/meta": {
+      "name": "temporalio",
       "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
@@ -12046,6 +12053,7 @@
       }
     },
     "packages/proto": {
+      "name": "@temporalio/proto",
       "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
@@ -12059,6 +12067,7 @@
       }
     },
     "packages/test": {
+      "name": "@temporalio/test",
       "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
@@ -12066,6 +12075,7 @@
         "@temporalio/activity": "file:../activity",
         "@temporalio/client": "file:../client",
         "@temporalio/common": "file:../common",
+        "@temporalio/interceptors-opentelemetry": "file:../interceptors-opentelemetry",
         "@temporalio/proto": "file:../proto",
         "@temporalio/worker": "file:../worker",
         "@temporalio/workflow": "file:../workflow",
@@ -12082,6 +12092,7 @@
       }
     },
     "packages/worker": {
+      "name": "@temporalio/worker",
       "version": "0.9.0",
       "hasInstallScript": true,
       "license": "MIT",
@@ -12130,6 +12141,7 @@
       }
     },
     "packages/workflow": {
+      "name": "@temporalio/workflow",
       "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
@@ -14072,6 +14084,7 @@
         "@temporalio/activity": "file:../activity",
         "@temporalio/client": "file:../client",
         "@temporalio/common": "file:../common",
+        "@temporalio/interceptors-opentelemetry": "file:../interceptors-opentelemetry",
         "@temporalio/proto": "file:../proto",
         "@temporalio/worker": "file:../worker",
         "@temporalio/workflow": "file:../workflow",

--- a/packages/interceptors-opentelemetry/package.json
+++ b/packages/interceptors-opentelemetry/package.json
@@ -4,10 +4,7 @@
   "description": "Temporal.io SDK interceptors bundle for tracing with opentelemetry",
   "main": "lib/index.js",
   "types": "./lib/index.d.ts",
-  "scripts": {
-    "build": "tsc --build",
-    "build.watch": "tsc --build --watch"
-  },
+  "scripts": {},
   "keywords": [
     "temporal",
     "workflow",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -26,6 +26,7 @@
     "@temporalio/activity": "file:../activity",
     "@temporalio/client": "file:../client",
     "@temporalio/common": "file:../common",
+    "@temporalio/interceptors-opentelemetry": "file:../interceptors-opentelemetry",
     "@temporalio/proto": "file:../proto",
     "@temporalio/worker": "file:../worker",
     "@temporalio/workflow": "file:../workflow",

--- a/packages/test/tsconfig.json
+++ b/packages/test/tsconfig.json
@@ -8,6 +8,7 @@
     { "path": "../activity" },
     { "path": "../client" },
     { "path": "../common" },
+    { "path": "../interceptors-opentelemetry" },
     { "path": "../worker" },
     { "path": "../workflow" }
   ],


### PR DESCRIPTION
I haven't confirmed this but I think our compilation is broken because we compile 2 projects (test and interceptors-opentelemetry) with shared project references.