### PR TITLE
feat: Expose option to enable direct prometheus scraping

### DIFF
--- a/packages/core-bridge/Cargo.lock
+++ b/packages/core-bridge/Cargo.lock
@@ -514,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
+checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
 dependencies = [
  "bytes",
  "fnv",
@@ -1449,6 +1449,7 @@ dependencies = [
  "futures",
  "futures-retry",
  "http",
+ "hyper",
  "itertools",
  "lazy_static",
  "log",
@@ -1552,9 +1553,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4efe6fc2395938c8155973d7be49fe8d03a843726e285e100a8a383cc0154ce"
+checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1706,9 +1707,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ba9ab62b7d6497a8638dfda5e5c4fb3b2d5a7fca4118f2b96151c8ef1a437e"
+checksum = "84f96e095c0c82419687c20ddf5cb3eadb61f4e1405923c9dc8e53a1adacbda8"
 dependencies = [
  "cfg-if",
  "log",
@@ -1783,9 +1784,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c42e73a9d277d4d2b6a88389a137ccf3c58599660b17e8f5fc39305e490669"
+checksum = "fdd0568dbfe3baf7048b7908d2b32bca0d81cd56bec6d2a8f894b01d74f86be3"
 dependencies = [
  "ansi_term",
  "chrono",

--- a/packages/core-bridge/index.d.ts
+++ b/packages/core-bridge/index.d.ts
@@ -88,6 +88,14 @@ export interface TelemetryOptions {
   /** What level, if any, logs should be forwarded from core at */
   // These strings should match the log::LevelFilter enum in rust
   logForwardingLevel: 'OFF' | LogLevel;
+  /** If set, metrics will be exposed on an http server in this process for direct scraping by
+   *  prometheus. If used in conjunction with the OTel collector, metrics will *not* be exported
+   *  to the collector, but traces will be.
+   *
+   *  The string provided must be an address the server will bind to. For example, `0.0.0.0:1234`.
+   *  Metrics will be available for scraping under the standard `/metrics` route.
+   */
+  prometheusMetricsBindAddress?: string;
 }
 
 export interface WorkerOptions {

--- a/packages/core-bridge/src/lib.rs
+++ b/packages/core-bridge/src/lib.rs
@@ -634,7 +634,7 @@ fn core_new(mut cx: FunctionContext) -> JsResult<JsUndefined> {
                     .unwrap()
                     .value(&mut cx),
             )
-            .unwrap()
+            .expect("`oTelCollectorUrl` in telemetry options must be valid")
         }),
         tracing_filter: get_optional(&mut cx, telem_options, "tracingFilter")
             .map(|x| {
@@ -644,6 +644,18 @@ fn core_new(mut cx: FunctionContext) -> JsResult<JsUndefined> {
             })
             .unwrap_or("".to_string()),
         log_forwarding_level,
+        prometheus_export_bind_address: get_optional(
+            &mut cx,
+            telem_options,
+            "prometheusMetricsBindAddress",
+        )
+        .map(|x| {
+            x.downcast_or_throw::<JsString, _>(&mut cx)
+                .unwrap()
+                .value(&mut cx)
+                .parse()
+                .expect("`prometheusMetricsBindAddress` in telemetry options must be valid")
+        }),
     };
 
     let callback = cx.argument::<JsFunction>(1)?.root(&mut cx);

--- a/packages/worker/src/core.ts
+++ b/packages/worker/src/core.ts
@@ -3,13 +3,13 @@ import { BehaviorSubject, lastValueFrom, of } from 'rxjs';
 import { concatMap, delay, map, repeat } from 'rxjs/operators';
 import { IllegalStateError } from '@temporalio/common';
 import * as native from '@temporalio/core-bridge';
-import { newCore, coreShutdown, TelemetryOptions, corePollLogs } from '@temporalio/core-bridge';
+import { corePollLogs, coreShutdown, newCore, TelemetryOptions } from '@temporalio/core-bridge';
 import {
-  ServerOptions,
   CompiledServerOptions,
-  getDefaultServerOptions,
   compileServerOptions,
+  getDefaultServerOptions,
   normalizeTlsConfig,
+  ServerOptions,
 } from './server-options';
 import { DefaultLogger, Logger } from './logger';
 import * as errors from './errors';
@@ -86,7 +86,7 @@ export class Core {
 
     if (options.telemetryOptions?.logForwardingLevel !== 'OFF') {
       const poll = promisify(corePollLogs);
-      const logPromise = lastValueFrom(
+      return lastValueFrom(
         of(this.shouldPollForLogs).pipe(
           map((subject) => subject.getValue()),
           concatMap((shouldPoll) => {
@@ -116,7 +116,6 @@ export class Core {
         if (error instanceof errors.ShutdownError) return;
         options.logger.warn('Error gathering forwarded logs from core', { error });
       });
-      return logPromise;
     }
     // Make sure to always return a Promise
     return Promise.resolve();


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Option to expose metrics endpoint for direct prometheus scraping

## Why?
Many users will likely only care about prometheus and not otel collector

## Checklist
<!--- add/delete as needed --->

1. Relates to https://github.com/temporalio/sdk-core/issues/85

2. How was this tested:
Verified server started properly

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
