### PR TITLE
fix: Node should not set indexed_fields for child search attrs

### DIFF
--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -259,9 +259,7 @@ async function startChildWorkflowExecutionNextHandler({
         parentClosePolicy: options.parentClosePolicy,
         cronSchedule: options.cronSchedule,
         searchAttributes: options.searchAttributes
-          ? {
-              indexedFields: mapToPayloadsSync(state.dataConverter, options.searchAttributes),
-            }
+          ? mapToPayloadsSync(state.dataConverter, options.searchAttributes)
           : undefined,
         memo: options.memo && mapToPayloadsSync(state.dataConverter, options.memo),
       },


### PR DESCRIPTION
Already handled by core

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Fixed node passing custom search attrs for child workflow command

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
